### PR TITLE
Add --all flag to update command.

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -673,7 +673,10 @@ def list():  # pragma: no cover
 
 
 @main.command(
-    short_help="Update modules on the device. Use --all to avoid confirmation."
+    short_help=(
+        "Update modules on the device. "
+        "Use --all to automatically update all modules."
+    )
 )
 @click.option("--all", is_flag=True)
 def update(all):  # pragma: no cover

--- a/circup.py
+++ b/circup.py
@@ -672,8 +672,11 @@ def list():  # pragma: no cover
         click.echo("All modules found on the device are up to date.")
 
 
-@main.command()
-def update():  # pragma: no cover
+@main.command(
+    short_help="Update modules on the device. Use --all to avoid confirmation."
+)
+@click.option("--all", is_flag=True)
+def update(all):  # pragma: no cover
     """
     Checks for out-of-date modules on the connected CIRCUITPYTHON device, and
     prompts the user to confirm updating such modules.
@@ -683,12 +686,16 @@ def update():  # pragma: no cover
     modules = [m for m in find_modules() if m.outofdate]
     if modules:
         click.echo("Found {} module[s] needing update.".format(len(modules)))
-        click.echo("Please indicate which modules you wish to update:\n")
+        if not all:
+            click.echo("Please indicate which modules you wish to update:\n")
         for module in modules:
-            if click.confirm("Update '{}'?".format(module.name)):
+            update_flag = all
+            if not update_flag:
+                update_flag = click.confirm("Update '{}'?".format(module.name))
+            if update_flag:
                 try:
                     module.update()
-                    click.echo("OK")
+                    click.echo("Updated {}".format(module.name))
                 except Exception as ex:
                     logger.exception(ex)
                     click.echo(


### PR DESCRIPTION
This very quick and simple change adds a feature requested by @makermelissa:

The update command now takes an `--all` flag which circumvents the confirmation checks for each out-of-date module and just updates everything automatically, with output to show what was updated. For example:

```
$ circup update --all
Found device at /media/ntoll/CIRCUITPY, running CircuitPython 4.1.0.
Found 7 module[s] needing update.
Updated adafruit_ntp
Updated adafruit_pyportal
Updated adafruit_ssd1306
Updated adafruit_st7789
Updated adafruit_apds9960
Updated adafruit_esp32spi
Updated adafruit_rgb_display
```

In terms of code, this is a pretty trivial change. No tests added since this is IO based stuff provided by the `click` module.