### PR TITLE
Add CHANGES.rst To PyPI Manifest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,22 @@
 Release History
 ===============
 
+
+0.0.3
+-----
+
+Automated Release Deployment Bug Fix
+
+* Fix missing PyPI egg dependency
+
+0.0.2
+-----
+
+Initial PyPI Release Automation w/ TravisCI
+
+* Add Continuous Integration with TravisCI
+* Deploy ``circup`` releases to PyPI automatically with TravisCI
+
 0.0.1
 -----
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CHANGES.rst

--- a/circup.py
+++ b/circup.py
@@ -83,7 +83,7 @@ logger.addHandler(logfile_handler)
 # somewhat naively by setup.py.
 __title__ = "circup"
 __description__ = "A tool to manage/update libraries on CircuitPython devices."
-__version__ = "0.0.1"
+__version__ = "0.0.3"
 __license__ = "MIT"
 __url__ = "https://github.com/adafruit/circup"
 __author__ = "Adafruit Industries"


### PR DESCRIPTION
As noted in #17, `setup.py` fails when installing from PyPI because `CHANGES.rst` is not distributed. This adds a `MANIFEST.in` file, which should force the file to be distributed.

Note: after merge, use tag `0.0.3` when releasing to match this with the version that will be annotated in PyPI.