### PR TITLE
Handle HTTP Error codes when ensuring bundle update.

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -502,9 +502,21 @@ def ensure_latest_bundle():
                 logger.exception(ex)
     if tag > old_tag:
         logger.info("New version available ({}).".format(tag))
-        get_bundle(tag)
-        with open(BUNDLE_DATA, "w", encoding="utf-8") as data:
-            json.dump({"tag": tag}, data)
+        try:
+            get_bundle(tag)
+            with open(BUNDLE_DATA, "w", encoding="utf-8") as data:
+                json.dump({"tag": tag}, data)
+        except requests.exceptions.HTTPError as ex:
+            # See #20 for reason this this
+            click.secho(
+                (
+                    "There was a problem downloading the bundle. "
+                    "Please try again in a moment."
+                ),
+                fg="red",
+            )
+            logger.exception(ex)
+            sys.exit(1)
     else:
         logger.info("Current library bundle up to date ({}).".format(tag))
 
@@ -761,10 +773,14 @@ def install(name, py):  # pragma: no cover
                 shutil.copyfile(source_path, target_path)
         else:
             # Use pre-compiled mpy modules.
-            module_name = os.path.basename(metadata["path"]).replace(".py", ".mpy")
+            module_name = os.path.basename(metadata["path"]).replace(
+                ".py", ".mpy"
+            )
             if not module_name:
                 # Must be a directory based module.
-                module_name = os.path.basename(os.path.dirname(metadata["path"]))
+                module_name = os.path.basename(
+                    os.path.dirname(metadata["path"])
+                )
             major_version = CPY_VERSION.split(".")[0]
             bundle_platform = "{}mpy".format(major_version)
             bundle_path = ""

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -26,6 +26,7 @@ import circup
 import ctypes
 import pytest
 import json
+import requests
 from unittest import mock
 
 
@@ -545,8 +546,8 @@ def test_ensure_latest_bundle_bad_bundle_data():
 
 def test_ensure_latest_bundle_to_update():
     """
-    If the version found in the BUNDLE_DATA is out of date, the cause an update
-    to the bundle.
+    If the version found in the BUNDLE_DATA is out of date, then cause an
+    update to the bundle.
     """
     with mock.patch("circup.get_latest_tag", return_value="54321"), mock.patch(
         "circup.os.path.isfile", return_value=True
@@ -559,6 +560,30 @@ def test_ensure_latest_bundle_to_update():
         circup.ensure_latest_bundle()
         mock_gb.assert_called_once_with("54321")
         assert mock_json.dump.call_count == 1  # Current version saved to file.
+
+
+def test_ensure_latest_bundle_to_update_http_error():
+    """
+    If an HTTP error happens during a bundle update, print a friendly
+    error message and exit 1.
+    """
+    with mock.patch("circup.get_latest_tag", return_value="54321"), mock.patch(
+        "circup.os.path.isfile", return_value=True
+    ), mock.patch("circup.open"), mock.patch(
+        "circup.get_bundle", side_effect=requests.exceptions.HTTPError("404")
+    ) as mock_gb, mock.patch(
+        "circup.json"
+    ) as mock_json, mock.patch(
+        "circup.click.secho"
+    ) as mock_click, mock.patch(
+        "circup.sys.exit"
+    ) as mock_exit:
+        mock_json.load.return_value = {"tag": "12345"}
+        circup.ensure_latest_bundle()
+        mock_gb.assert_called_once_with("54321")
+        assert mock_json.dump.call_count == 0  # not saved.
+        mock_click.call_count == 1  # friendly message.
+        mock_exit.assert_called_once_with(1)  # exit 1.
 
 
 def test_ensure_latest_bundle_no_update():


### PR DESCRIPTION
Fixes #20.

This PR introduces two changes:

* If an HTTP error code is encountered when updating the bundle release, then log the error, print a friendly error message and sys.exit 1 (error).
* Tests for the above.

Thanks to @makermelissa for reporting this problem. :+1: