### PR TITLE
Run circup via `python -m circup`

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -805,6 +805,7 @@ def install(name, py):  # pragma: no cover
     else:
         click.echo("Unknown module named, '{}'.".format(name))
 
+
 # Allows execution via `python -m circup ...`
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/circup.py
+++ b/circup.py
@@ -804,3 +804,7 @@ def install(name, py):  # pragma: no cover
         click.echo("Installed '{}'.".format(name))
     else:
         click.echo("Unknown module named, '{}'.".format(name))
+
+# Allows execution via `python -m circup ...`
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This will help accommodate users who are using [joedevivo/vscode-circuitpython](https://github.com/joedevivo/vscode-circuitpython), have selected a python interpreter managed by asdf, and have never used circup before.

This is because after an asdf python installs a package, it needs to be "reshim"ed before the circup command is available.