### PR TITLE
Add requirement.txt support for freeze and install commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,9 +62,11 @@ To get help, just type the command::
       A tool to manage and update libraries on a CircuitPython device.
 
     Options:
-      --verbose  Comprehensive logging is sent to stdout.
-      --version  Show the version and exit.
-      --help     Show this message and exit.
+      --verbose         Comprehensive logging is sent to stdout.
+      --version         Show the version and exit.
+      --help            Show this message and exit.
+      -r --requirement  Supports requirements.txt tracking of library
+                        requirements with freeze and install commands.
 
     Commands:
       freeze     Output details of all the modules found on the connected...
@@ -83,6 +85,10 @@ CIRCUITPYTHON device::
     adafruit_binascii==v1.0
     adafruit_bme280==2.3.1
     adafruit_ble==1.0.2
+
+With :code:`$ circup freeze -r`, Circup will save, in the current working directory,
+a requirements.txt file with a list of all modules currently installed on the
+connected device.
 
 To list all the modules that require an update::
 
@@ -104,6 +110,21 @@ To interactively update the out-of-date modules::
     OK
     Update 'adafruit_ble'? [y/N]: Y
     OK
+
+Install a module onto the connected device with::
+
+    $ circup install adafruit_thermal_printer
+    Installed 'adafruit_thermal_printer'.
+
+You can also install a list of modules from a requirements.txt file in
+the current working directory with::
+
+    $ circup install -r requirements.txt
+    Installed 'adafruit_bmp280'.
+    Installed 'adafruit_lis3mdl'.
+    Installed 'adafruit_lsm6ds'.
+    Installed 'adafruit_sht31d'.
+    Installed 'neopixel'.
 
 Uninstall a module like this::
 

--- a/circup.py
+++ b/circup.py
@@ -635,18 +635,28 @@ def main(verbose):  # pragma: no cover
 
 
 @main.command()
-def freeze():  # pragma: no cover
+@click.option("-r", "--requirement", is_flag=True)
+def freeze(requirement):  # pragma: no cover
     """
     Output details of all the modules found on the connected CIRCUITPYTHON
-    device.
+    device. Option -r saves output to requirements.txt file
     """
     logger.info("Freeze")
     modules = find_modules()
     if modules:
+        output = []
         for module in modules:
-            output = "{}=={}".format(module.name, module.device_version)
-            click.echo(output)
-            logger.info(output)
+            output.append("{}=={}".format(module.name, module.device_version))
+        for module in output:
+            click.echo(module)
+            logger.info(module)
+        if requirement:
+            cwd = os.path.abspath(os.getcwd())
+            for i, module in enumerate(output):
+                output[i] += "\r\n"
+            with open(cwd + "/" + "requirements.txt", "w") as file:
+                file.truncate(0)
+                file.writelines(output)
     else:
         click.echo("No modules found on the device.")
 


### PR DESCRIPTION
This adds support for managing project module requirements through a requirements.txt file. The freeze command can now output a requirements.txt file for all modules installed on a connected device. The install command can then use the requirements.txt file to install a list of requirements to a connected device.

The expected workflow would be that a project could export a requirements.txt file with the modules required for their project and provide the file in the project source. Another user could then quickly install all of the required modules for the project onto their device.

This is built on top of the existing install command which does not consider module versions. For later I think as there would need to be a way to organize all of the module versions.

Close #29