### PR TITLE
Bump version of click in package dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ black==19.3b0
 bleach==3.1.4
 certifi==2019.6.16
 chardet==3.0.4
-Click==7.0
+Click>=7.0
 coverage==4.5.4
 docutils==0.15.2
 idna==2.8

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 install_requires = [
     "semver>=2.8.1",
-    "Click==7.0",
+    "Click>=7.0",
     "appdirs>=1.4.3",
     "requests>=2.22.0",
 ]


### PR DESCRIPTION
* This PR fixes #39 (no known package of `Click` for Python3.9).
* I've allowed the latest version of `Click`(rather than a pinned version) to be installed.
* This is a quick fix and I don't currently have any devices to hand in order to test this change (sorry).
* Before merging please `pip install .` in a Python3.9 virtualenv and try the command out to ensure the bump in version for the package `Click` doesn't break anything.

Of course, given the quick nature of this PR please don't hesitate to discard it.