### PR TITLE
Warn on major version changes

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -31,7 +31,7 @@ import shutil
 import json
 import zipfile
 from subprocess import check_output
-from semver import compare
+from semver import compare, VersionInfo
 import click
 import requests
 import appdirs
@@ -160,6 +160,21 @@ class Module:
         return True  # Assume out of date to try to update.
 
     @property
+    def major_update(self):
+        """
+        Returns a boolean to indicate if this is a major version update.
+
+        :return: Boolean indicating if this is a major version upgrade
+        """
+        if (
+            VersionInfo.parse(self.device_version).major
+            == VersionInfo.parse(self.bundle_version).major
+        ):
+            return False
+        else:
+            return True
+
+    @property
     def row(self):
         """
         Returns a tuple of items to display in a table row to show the module's
@@ -170,7 +185,8 @@ class Module:
         """
         loc = self.device_version if self.device_version else "unknown"
         rem = self.bundle_version if self.bundle_version else "unknown"
-        return (self.name, loc, rem)
+        major_update = str(self.major_update)
+        return (self.name, loc, rem, major_update)
 
     def update(self):
         """
@@ -651,23 +667,25 @@ def list():  # pragma: no cover
     """
     logger.info("List")
     # Grab out of date modules.
-    data = [("Module", "Version", "Latest")]
+    data = [("Module", "Version", "Latest", "Major Update")]
+
     modules = [m.row for m in find_modules() if m.outofdate]
     if modules:
         data += modules
         # Nice tabular display.
-        col_width = [0, 0, 0]
+        col_width = [0, 0, 0, 0]
         for row in data:
             for i, word in enumerate(row):
                 col_width[i] = max(len(word) + 2, col_width[i])
         dashes = tuple(("-" * (width - 1) for width in col_width))
         data.insert(1, dashes)
         click.echo(
-            "The following modules are out of date or probably need " "an update.\n"
+            "The following modules are out of date or probably need an update.\n"
+            "Major Updates may include breaking changes. Review before updating.\n"
         )
         for row in data:
             output = ""
-            for i in range(3):
+            for i in range(len(row)):
                 output += row[i].ljust(col_width[i])
             if not VERBOSE:
                 click.echo(output)
@@ -679,10 +697,10 @@ def list():  # pragma: no cover
 @main.command(
     short_help=(
         "Update modules on the device. "
-        "Use --all to automatically update all modules."
+        "Use --all to automatically update all modules without Major Version warnings."
     )
 )
-@click.option("--all", is_flag=True)
+@click.option("--all", is_flag=True, help="Update all modules without Major Version warnings.")
 def update(all):  # pragma: no cover
     """
     Checks for out-of-date modules on the connected CIRCUITPYTHON device, and
@@ -698,7 +716,10 @@ def update(all):  # pragma: no cover
         for module in modules:
             update_flag = all
             if not update_flag:
-                update_flag = click.confirm("Update '{}'?".format(module.name))
+                if module.major_update:
+                    update_flag = click.confirm("'{}' is a Major Version update and may contain breaking changes. Do you want to update?".format(module.name))
+                else:
+                    update_flag = click.confirm("Update '{}'?".format(module.name))
             if update_flag:
                 # pylint: disable=broad-except
                 try:

--- a/circup.py
+++ b/circup.py
@@ -685,8 +685,8 @@ def list():  # pragma: no cover
         )
         for row in data:
             output = ""
-            for i in range(len(row)):
-                output += row[i].ljust(col_width[i])
+            for index, cell in enumerate(row):
+                output += cell.ljust(col_width[index])
             if not VERBOSE:
                 click.echo(output)
             logger.info(output)
@@ -700,7 +700,9 @@ def list():  # pragma: no cover
         "Use --all to automatically update all modules without Major Version warnings."
     )
 )
-@click.option("--all", is_flag=True, help="Update all modules without Major Version warnings.")
+@click.option(
+    "--all", is_flag=True, help="Update all modules without Major Version warnings."
+)
 def update(all):  # pragma: no cover
     """
     Checks for out-of-date modules on the connected CIRCUITPYTHON device, and
@@ -717,7 +719,12 @@ def update(all):  # pragma: no cover
             update_flag = all
             if not update_flag:
                 if module.major_update:
-                    update_flag = click.confirm("'{}' is a Major Version update and may contain breaking changes. Do you want to update?".format(module.name))
+                    update_flag = click.confirm(
+                        (
+                            "'{}' is a Major Version update and may contain breaking "
+                            "changes. Do you want to update?".format(module.name)
+                        )
+                    )
                 else:
                     update_flag = click.confirm("Update '{}'?".format(module.name))
             if update_flag:

--- a/circup.py
+++ b/circup.py
@@ -166,12 +166,16 @@ class Module:
 
         :return: Boolean indicating if this is a major version upgrade
         """
-        if (
-            VersionInfo.parse(self.device_version).major
-            == VersionInfo.parse(self.bundle_version).major
-        ):
-            return False
-        return True
+        try:
+            if (
+                VersionInfo.parse(self.device_version).major
+                == VersionInfo.parse(self.bundle_version).major
+            ):
+                return False
+        except TypeError as ex:
+            logger.warning("Module '%s' has incorrect semver value.", self.name)
+            logger.warning(ex)
+        return True  # Assume Major Version udpate.
 
     @property
     def row(self):

--- a/circup.py
+++ b/circup.py
@@ -171,8 +171,7 @@ class Module:
             == VersionInfo.parse(self.bundle_version).major
         ):
             return False
-        else:
-            return True
+        return True
 
     @property
     def row(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pytz==2019.2
 readme-renderer==24.0
 requests==2.22.0
 requests-toolbelt==0.9.1
-semver==2.8.1
+semver==2.11.0
 six==1.12.0
 snowballstemmer==1.9.0
 Sphinx==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    "semver>=2.8.1",
+    "semver==2.11.0",
     "Click>=7.0",
     "appdirs>=1.4.3",
     "requests>=2.22.0",

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -132,7 +132,9 @@ def test_Module_row():
     bundle_path = os.path.join("baz", "bar", "foo", "module.py")
     with mock.patch("circup.os.path.isfile", return_value=True):
         m = circup.Module(path, repo, device_version, bundle_version, bundle_path)
-    assert m.row == ("module", "1.2.3", "unknown")
+    # print(m.__dict__)
+    # print(m.row)
+    assert m.row == ("module", "1.2.3", "unknown", "True")
 
 
 def test_Module_update_dir():


### PR DESCRIPTION
Fixes #25 

This warns the user both in the list and the in update command if an update is a major version update.
This is NOT done when using update --all, which sort of makes --all a bit more like --force in other CLI tools.

The text I chose to add to the CLI help and the prompts could probably use a little tweaking.