### PR TITLE
Don't pass version and Click will figure it out

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.pythonPath": "/Users/askpatrickw/.pyenv/versions/cp_base/bin/python",
-    "python.linting.pylintEnabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.pythonPath": "/Users/askpatrickw/.pyenv/versions/cp_base/bin/python",
+    "python.linting.pylintEnabled": true
+}

--- a/circup.py
+++ b/circup.py
@@ -564,7 +564,6 @@ def get_bundle(tag):
     "--verbose", is_flag=True, help="Comprehensive logging is sent to stdout."
 )
 @click.version_option(
-    version=__version__,
     prog_name="CircUp",
     message="%(prog)s, A CircuitPython module updater. Version %(version)s",
 )


### PR DESCRIPTION
This fixes #48 

Click has builtin cross python support to figure this out and we are using click's version_option, but we were passing __version__. If we don't do that, Click figures it out for us correctly.