### PR TITLE
add make\   to call to make.py

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -1,1 +1,1 @@
-python make.py %*
+python make\make.py %*


### PR DESCRIPTION
after make.py was moved to make subdirectory, make.cmd needed to be edited to add make\ to call.