### PR TITLE
update to latest stable semver

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -144,7 +144,9 @@ class Module:
         """
         if self.device_version and self.bundle_version:
             try:
-                return VersionInfo.parse(self.device_version) < VersionInfo.parse(self.bundle_version)
+                return VersionInfo.parse(self.device_version) < VersionInfo.parse(
+                    self.bundle_version
+                )
             except ValueError as ex:
                 logger.warning("Module '%s' has incorrect semver value.", self.name)
                 logger.warning(ex)

--- a/circup.py
+++ b/circup.py
@@ -31,7 +31,7 @@ import shutil
 import json
 import zipfile
 from subprocess import check_output
-from semver import compare, VersionInfo
+from semver import VersionInfo
 import click
 import requests
 import appdirs

--- a/circup.py
+++ b/circup.py
@@ -31,7 +31,7 @@ import shutil
 import json
 import zipfile
 from subprocess import check_output
-from semver import compare
+from semver import VersionInfo, parse
 import click
 import requests
 import appdirs
@@ -144,7 +144,7 @@ class Module:
         """
         if self.device_version and self.bundle_version:
             try:
-                return compare(self.device_version, self.bundle_version) < 0
+                return VersionInfo.parse(self.device_version) < VersionInfo.parse(self.bundle_version)
             except ValueError as ex:
                 logger.warning("Module '%s' has incorrect semver value.", self.name)
                 logger.warning(ex)
@@ -595,7 +595,7 @@ def main(verbose):  # pragma: no cover
     )
     latest_version = cp_release.url.split("/")[-1]
     try:
-        if compare(CPY_VERSION, latest_version) < 0:
+        if VersionInfo.parse(CPY_VERSION) < VersionInfo.parse(latest_version):
             click.secho(
                 "A newer version of CircuitPython ({}) is available.".format(
                     latest_version

--- a/circup.py
+++ b/circup.py
@@ -31,7 +31,7 @@ import shutil
 import json
 import zipfile
 from subprocess import check_output
-from semver import VersionInfo, parse
+from semver import VersionInfo
 import click
 import requests
 import appdirs

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pytz==2019.2
 readme-renderer==24.0
 requests==2.22.0
 requests-toolbelt==0.9.1
-semver==2.8.1
+semver~=2.13
 six==1.12.0
 snowballstemmer==1.9.0
 Sphinx==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 install_requires = [
-    "semver>=2.8.1",
+    "semver~=2.13",
     "Click>=7.0",
     "appdirs>=1.4.3",
     "requests>=2.22.0",


### PR DESCRIPTION
Fixes #53 

This updates semver to the latest stable and makes the code changes to switch from semver.compare() which is soon to be deprecated. Converting the stings to VersionInfo and then comparing is straight-forward.

Local testing passed.