### PR TITLE
Fix 65 - Multi module install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ To get help, just type the command::
 
     Commands:
       freeze        Output details of all the modules found on the connected...
-      install       Install a named module onto the device.
+      install       Install a named module(s) onto the device.
       list          Lists all out of date modules found on the connected...
       show          Show the long list of all available modules in the bundle.
       show <query>  Search the names in the modules in the bundle for a match.
@@ -126,10 +126,14 @@ To interactively update the out-of-date modules::
     Update 'adafruit_ble'? [y/N]: Y
     OK
 
-Install a module onto the connected device with::
+Install a module or modules onto the connected device with::
 
     $ circup install adafruit_thermal_printer
     Installed 'adafruit_thermal_printer'.
+
+    $ circup install adafruit_thermal_printer adafruit_bus_io
+    Installed 'adafruit_thermal_printer'.
+    Installed 'adafruit_bus_io'.
 
 You can also install a list of modules from a requirements.txt file in
 the current working directory with::
@@ -141,10 +145,14 @@ the current working directory with::
     Installed 'adafruit_sht31d'.
     Installed 'neopixel'.
 
-Uninstall a module like this::
+Uninstall a module or modules like this::
 
     $ circup uninstall adafruit_thermal_printer
     Uninstalled 'adafruit_thermal_printer'.
+
+    $ circup uninstall adafruit_thermal_printer adafruit_bus_io
+    Uninstalled 'adafruit_thermal_printer'.
+    Uninstalled 'adafruit_bus_io'.
 
 Use the ``--verbose`` flag to see the logs as the command is working::
 

--- a/circup.py
+++ b/circup.py
@@ -789,7 +789,7 @@ def install_module(device_path, name, py, mod_names):  # pragma: no cover
     TODO: There is currently no check for the version.
     """
     if not name:
-        click.echo("No module name provided.")
+        click.echo("No module name(s) provided.")
     elif name in mod_names:
         library_path = os.path.join(device_path, "lib")
         if not os.path.exists(library_path):  # pragma: no cover
@@ -848,15 +848,17 @@ def install_module(device_path, name, py, mod_names):  # pragma: no cover
 
 
 @main.command()
-@click.argument("names", required=False, nargs=-1)
+@click.argument("modules", required=False, nargs=-1)
 @click.option("--py", is_flag=True)
 @click.option("-r", "--requirement")
 @click.pass_context
-def install(ctx, names, py, requirement):  # pragma: no cover
+def install(ctx, modules, py, requirement):  # pragma: no cover
     """
-    Install a named module onto the device. This is a very naive / simple
-    hacky proof of concept. Option -r allows specifying a text file to
-    install all modules listed in the text file.
+    Install a named module(s) onto the device. Multiple modules
+    can be installed at once by providing more than one module name, each
+    separated by a space.
+    Option -r allows specifying a text file to install all modules listed in
+    the text file.
 
     TODO: Work out how to specify / handle dependencies (if at all), ensure
     there's enough space on the device, work out the version of CircuitPython
@@ -864,8 +866,7 @@ def install(ctx, names, py, requirement):  # pragma: no cover
     """
     available_modules = get_bundle_versions()
     # Normalize user input.
-    for name in names:
-        print(name)
+    for name in modules:
         name = name.lower() if name else ""
         mod_names = {}
         for module, metadata in available_modules.items():

--- a/circup.py
+++ b/circup.py
@@ -848,11 +848,11 @@ def install_module(device_path, name, py, mod_names):  # pragma: no cover
 
 
 @main.command()
-@click.argument("name", required=False)
+@click.argument("names", required=False, nargs=-1)
 @click.option("--py", is_flag=True)
 @click.option("-r", "--requirement")
 @click.pass_context
-def install(ctx, name, py, requirement):  # pragma: no cover
+def install(ctx, names, py, requirement):  # pragma: no cover
     """
     Install a named module onto the device. This is a very naive / simple
     hacky proof of concept. Option -r allows specifying a text file to
@@ -864,22 +864,24 @@ def install(ctx, name, py, requirement):  # pragma: no cover
     """
     available_modules = get_bundle_versions()
     # Normalize user input.
-    name = name.lower() if name else ""
-    mod_names = {}
-    for module, metadata in available_modules.items():
-        mod_names[module.replace(".py", "").lower()] = metadata
-    if requirement:
-        cwd = os.path.abspath(os.getcwd())
-        with open(cwd + "/" + requirement, "r") as file:
-            for line in file.readlines():
-                # Ignore comment lines or appended comment annotations.
-                line = line.split("#", 1)[0]
-                line = line.strip()  # Remove whitespace (including \n).
-                if line:  # Ignore blank lines.
-                    module = line.split("==")[0] if "==" in line else line
-                    install_module(ctx.obj["DEVICE_PATH"], module, py, mod_names)
-    else:
-        install_module(ctx.obj["DEVICE_PATH"], name, py, mod_names)
+    for name in names:
+        print(name)
+        name = name.lower() if name else ""
+        mod_names = {}
+        for module, metadata in available_modules.items():
+            mod_names[module.replace(".py", "").lower()] = metadata
+        if requirement:
+            cwd = os.path.abspath(os.getcwd())
+            with open(cwd + "/" + requirement, "r") as file:
+                for line in file.readlines():
+                    # Ignore comment lines or appended comment annotations.
+                    line = line.split("#", 1)[0]
+                    line = line.strip()  # Remove whitespace (including \n).
+                    if line:  # Ignore blank lines.
+                        module = line.split("==")[0] if "==" in line else line
+                        install_module(ctx.obj["DEVICE_PATH"], module, py, mod_names)
+        else:
+            install_module(ctx.obj["DEVICE_PATH"], name, py, mod_names)
 
 
 @main.command()


### PR DESCRIPTION
Fixes #65 

This was pretty straight-forward.

Using the [nargs parameter of the click.arguments](https://click.palletsprojects.com/en/7.x/arguments/?highlight=click%20argument#variadic-arguments) allows you accept more than one library and then it is just iterating over that tuple. As I was re-reviewing this to update the readme, I see the uninstall already had this. 

I tested install and uninstall with a single package and 4 packages, --verbose --py as well.
