### PR TITLE
Accept version strings with v

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -174,7 +174,7 @@ class Module:
                 == VersionInfo.parse(self.bundle_version).major
             ):
                 return False
-        except TypeError as ex:
+        except (TypeError, ValueError) as ex:
             logger.warning("Module '%s' has incorrect semver value.", self.name)
             logger.warning(ex)
         return True  # Assume Major Version udpate.

--- a/circup.py
+++ b/circup.py
@@ -1054,6 +1054,17 @@ def update(ctx, all):  # pragma: no cover
                         module.device_version, module.bundle_version
                     )
                 )
+            if isinstance(module.bundle_version, str) and not VersionInfo.isvalid(
+                module.bundle_version
+            ):
+                click.secho(
+                    f"WARNING: Library {module.name} repo has incorrect __version__"
+                    "\n\tmetadata. Circup will assume it needs updating."
+                    "\n\tPlease file an issue in the library repo.",
+                    fg="yellow",
+                )
+                if module.repo:
+                    click.secho(f"\t{module.repo}", fg="yellow")
             if not update_flag:
                 if module.major_update:
                     update_flag = click.confirm(

--- a/circup.py
+++ b/circup.py
@@ -439,7 +439,7 @@ def find_modules(device_path):
             if name in bundle_modules:
                 bundle_metadata = bundle_modules[name]
                 path = device_metadata["path"]
-                repo = device_metadata.get("__repo__")
+                repo = bundle_metadata.get("__repo__")
                 device_version = device_metadata.get("__version__")
                 bundle_version = bundle_metadata.get("__version__")
                 mpy = device_metadata["mpy"]

--- a/tests/device.json
+++ b/tests/device.json
@@ -1,7 +1,6 @@
 {
   "adafruit_74hc595.py": {
     "__version__": "1.0.2",
-    "__repo__": "https://github.com/adafruit/Adafruit_CircuitPython_74HC595.git",
     "path": "/media/ntoll/CIRCUITPY/lib/adafruit_74hc595.py",
     "mpy": false
   }

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -121,6 +121,24 @@ def test_Module_outofdate_bad_versions():
         assert mock_logger.call_count == 2
 
 
+def test_Module_major_update_bad_versions():
+    """
+    Sometimes, the version is not a valid semver value. In this case, the
+    ``major_update`` property assumes the module is a major update, so as not
+    to block the user from getting the latest update.
+    Such a problem should be logged.
+    """
+    path = os.path.join("foo", "bar", "baz", "module.py")
+    repo = "https://github.com/adafruit/SomeLibrary.git"
+    device_version = "1.2.3"
+    bundle_version = "version-3"
+    bundle_path = os.path.join("baz", "bar", "foo", "module.py")
+    m = circup.Module(path, repo, device_version, bundle_version, bundle_path)
+    with mock.patch("circup.logger.warning") as mock_logger:
+        assert m.major_update is True
+        assert mock_logger.call_count == 2
+
+
 def test_Module_row():
     """
     Ensure the tuple contains the expected items to be correctly displayed in
@@ -356,6 +374,10 @@ def test_find_modules():
         result = circup.find_modules("")
     assert len(result) == 1
     assert result[0].name == "adafruit_74hc595"
+    assert (
+        result[0].repo
+        == "https://github.com/adafruit/Adafruit_CircuitPython_74HC595.git"
+    )
 
 
 def test_find_modules_goes_bang():


### PR DESCRIPTION
Adds a "clean_version" function that removes the v in front of the version number so semver won't choke on it. There is a related idea that does a little more in the semver documentation:
https://python-semver.readthedocs.io/en/2.13.0/usage.html#dealing-with-invalid-versions

Also changes expecting a _`ValueError` in addition to a `TypeError`_ in `Module.major_update()`, so that bad version strings are caught. This fixes crashing circup. Remaining bad version numbers are assumed to be major updates.

This PR fixes #79 in regards to the adafruit_si7021 version. But adafruit_rplidar's `0.0.1-auto.0`, from which we can't extract the real version number anyway, will simply be assumed to need updating.