### PR TITLE
Reduce bandwidth to github when running CircUp

### DIFF
--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -311,21 +311,21 @@ def test_find_device_unknown_os():
     assert ex.value.args[0] == 'OS "foo" not supported.'
 
 
-def test_get_latest_tag():
+def test_get_latest_release_from_url():
     """
     Ensure the expected tag value is extracted from the returned URL (resulting
     from a call to the expected endpoint).
     """
     response = mock.MagicMock()
-    response.url = (
-        "https://github.com/adafruit"
+    response.headers = {
+        "Location": "https://github.com/adafruit"
         "/Adafruit_CircuitPython_Bundle/releases/tag/20190903"
-    )
+    }
     expected_url = (
         "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest"
     )
-    with mock.patch("circup.requests.get", return_value=response) as mock_get:
-        result = circup.get_latest_tag()
+    with mock.patch("circup.requests.head", return_value=response) as mock_get:
+        result = circup.get_latest_release_from_url(expected_url)
         assert result == "20190903"
         mock_get.assert_called_once_with(expected_url)
 


### PR DESCRIPTION
There are two `requests.get()` calls to github which are used to extract release/latest tag information and in the process download the entire page. These have been replaced with a new function `get_latest_release_from_url()` which uses `requests.head()` and the response headers parsed for a 'Location' and the tag extracted from this.

`get_latest_tag()` is potentially called often and does not store it's result. This leads to a full page download from github for every library checked. This has been replaced with a single call from `main()` and the result is stored in the global `LATEST_BUNDLE_VERSION`.

**Note:** This breaks the tests and I don't know the best way to go about fixing this. This is the reason for the Draft status.


**BEFORE:**
```
❯ rm -rf ~/.local/share/circup/

pi in strawberry in ~/projects/testspace via 🐍 v3.7.3 (testspace)

❯ circup --verbose install adafruit_neopixel simpleio adafruit_trellis| grep " Re"
03/24/2021 15:11:14 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:14 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:19 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:20 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:20 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:20 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:20 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:20 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:20 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:20 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:20 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:20 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:21 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:21 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:21 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:22 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:22 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:22 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:23 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:23 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324
03/24/2021 15:11:24 INFO: Requesting tag information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
03/24/2021 15:11:24 INFO: Response url: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20210324

pi in strawberry in ~/projects/testspace via 🐍 v3.7.3 (testspace)took 12s
```
**AFTER:**
```
❯ rm -rf ~/.local/share/circup/

pi in strawberry in circup on head-redirect via 🐍 v3.7.3 (testspace)

❯ python circup.py --verbose install adafruit_neopixel simpleio adafruit_trellis| grep " Re"
03/24/2021 15:16:37 INFO: Requesting redirect information: https://github.com/adafruit/circuitpython/releases/latest
03/24/2021 15:16:37 INFO: Requesting redirect information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest

pi in strawberry in circup on head-redirect via 🐍 v3.7.3 (testspace)took 7s
```
