### PR TITLE
Add missing read the docs config

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+requirements_file: requirements.txt


### PR DESCRIPTION
RTD has been failing
https://readthedocs.org/projects/circup/builds/13343939/

Adding this config file which matches the cookiecutter repo so RTD knows the name of the requirements file. It is defaulting to rtd_requirements.