### PR TITLE
Add support for CP7 MPY bundles

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -463,6 +463,11 @@ def get_bundle(tag):
             "releases/download"
             "/{tag}/adafruit-circuitpython-bundle-6.x-mpy-{tag}.zip".format(tag=tag)
         ),
+        "7mpy": (
+            "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/"
+            "releases/download"
+            "/{tag}/adafruit-circuitpython-bundle-7.x-mpy-{tag}.zip".format(tag=tag)
+        ),
     }
     click.echo("Downloading latest version information.\n")
     for platform, url in urls.items():

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -638,11 +638,11 @@ def test_get_bundle():
         mock_requests.get.reset_mock()
         tag = "12345"
         circup.get_bundle(tag)
-        assert mock_requests.get.call_count == 2
-        assert mock_open.call_count == 2
-        assert mock_shutil.rmtree.call_count == 2
-        assert mock_zipfile.ZipFile.call_count == 2
-        assert mock_zipfile.ZipFile().__enter__().extractall.call_count == 2
+        assert mock_requests.get.call_count == 3
+        assert mock_open.call_count == 3
+        assert mock_shutil.rmtree.call_count == 3
+        assert mock_zipfile.ZipFile.call_count == 3
+        assert mock_zipfile.ZipFile().__enter__().extractall.call_count == 3
 
 
 def test_get_bundle_network_error():


### PR DESCRIPTION
Related to #98 
I woke up this morning and remembered we need to add 7mpy directly.
This adds the 7mpy url for download and bumps the tests up by 1.