### PR TITLE
add module names completion for install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,15 +230,15 @@ In order to activate shell completion, you need to inform your shell that comple
 
 For Bash, add this to ~/.bashrc::
 
-    eval "$(_CIRCUP_COMPLETE=source_bash circup)"
+    eval "$(_CIRCUP_COMPLETE=bash_source circup)"
 
 For Zsh, add this to ~/.zshrc::
 
-    eval "$(_CIRCUP_COMPLETE=source_zsh circup)"
+    eval "$(_CIRCUP_COMPLETE=zsh_source circup)"
 
 For Fish, add this to ~/.config/fish/completions/foo-bar.fish::
 
-    eval (env _CIRCUP_COMPLETE=source_fish circup)
+    eval (env _CIRCUP_COMPLETE=fish_source circup)
 
 Open a new shell to enable completion. Or run the eval command directly in your current shell to enable it temporarily.
 ### Activation Script
@@ -249,15 +249,15 @@ Alternatively, export the generated completion code as a static script to be exe
 
 For Bash::
 
-    _CIRCUP_COMPLETE=source_bash circup circup-complete.sh
+    _CIRCUP_COMPLETE=bash_source circup circup-complete.sh
 
 For Zsh::
 
-    _CIRCUP_COMPLETE=source_zsh circup circup-complete.sh
+    _CIRCUP_COMPLETE=zsh_source circup circup-complete.sh
 
 For Fish::
 
-    _CIRCUP_COMPLETE=source_zsh circup circup-complete.sh
+    _CIRCUP_COMPLETE=fish_source circup circup-complete.sh
 
 In .bashrc or .zshrc, source the script instead of the eval command::
 
@@ -265,7 +265,7 @@ In .bashrc or .zshrc, source the script instead of the eval command::
 
 For Fish, add the file to the completions directory::
 
-    _CIRCUP_COMPLETE=source_fish circup ~/.config/fish/completions/circup-complete.fish
+    _CIRCUP_COMPLETE=fish_source circup ~/.config/fish/completions/circup-complete.fish
 
 
 .. note::

--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,63 @@ The ``--version`` flag will tell you the current version of the
 
 That's it!
 
+
+Library Name Autocomplete
+-------------------------
+
+When enabled, circup will autocomplete library names, simliar to other command line tools.
+
+For example:
+
+  ``circup install n`` + tab -``circup install neopixel`` (+tab: offers ``neopixel`` and ``neopixel_spi`` completions)
+
+  ``circup install a`` + tab -``circup install adafruit\_`` + m a g + tab -``circup install adafruit_magtag``
+
+How to Activate Library Name Autocomplete
+-----------------------------------------
+
+In order to activate shell completion, you need to inform your shell that completion is available for your script. Any Click application automatically provides support for that.
+
+For Bash, add this to ~/.bashrc::
+
+    eval "$(_CIRCUP_COMPLETE=source_bash circup)"
+
+For Zsh, add this to ~/.zshrc::
+
+    eval "$(_CIRCUP_COMPLETE=source_zsh circup)"
+
+For Fish, add this to ~/.config/fish/completions/foo-bar.fish::
+
+    eval (env _CIRCUP_COMPLETE=source_fish circup)
+
+Open a new shell to enable completion. Or run the eval command directly in your current shell to enable it temporarily.
+### Activation Script
+
+The above eval examples will invoke your application every time a shell is started. This may slow down shell startup time significantly.
+
+Alternatively, export the generated completion code as a static script to be executed. You can ship this file with your builds; tools like Git do this. At least Zsh will also cache the results of completion files, but not eval scripts.
+
+For Bash::
+
+    _CIRCUP_COMPLETE=source_bash circup circup-complete.sh
+
+For Zsh::
+
+    _CIRCUP_COMPLETE=source_zsh circup circup-complete.sh
+
+For Fish::
+
+    _CIRCUP_COMPLETE=source_zsh circup circup-complete.sh
+
+In .bashrc or .zshrc, source the script instead of the eval command::
+
+    . /path/to/circup-complete.sh
+
+For Fish, add the file to the completions directory::
+
+    _CIRCUP_COMPLETE=source_fish circup ~/.config/fish/completions/circup-complete.fish
+
+
 .. note::
 
     If you find a bug, or you want to suggest an enhancement or new feature

--- a/circup.py
+++ b/circup.py
@@ -391,7 +391,7 @@ def completion_for_install(ctx, param, incomplete):
     with the ``circup install`` command.
     """
     # pylint: disable=unused-argument
-    available_modules = get_bundle_versions()
+    available_modules = get_bundle_versions(get_bundles_list())
     module_names = {m.replace(".py", "") for m in available_modules}
     if incomplete:
         module_names = [name for name in module_names if name.startswith(incomplete)]

--- a/circup.py
+++ b/circup.py
@@ -385,7 +385,7 @@ def clean_library_name(assumed_library_name):
     return assumed_library_name
 
 
-def completion_for_install(ctx, args, incomplete):
+def completion_for_install(ctx, param, incomplete):
     """
     Returns the list of available modules for the command line tab-completion
     with the ``circup install`` command.
@@ -393,8 +393,6 @@ def completion_for_install(ctx, args, incomplete):
     # pylint: disable=unused-argument
     available_modules = get_bundle_versions()
     module_names = {m.replace(".py", "") for m in available_modules}
-    # remove modules already listed (no other arg should be a module name)
-    module_names = module_names - set(args)
     if incomplete:
         module_names = [name for name in module_names if name.startswith(incomplete)]
     return sorted(module_names)
@@ -1118,7 +1116,7 @@ def list(ctx):  # pragma: no cover
 
 @main.command()
 @click.argument(
-    "modules", required=False, nargs=-1, autocompletion=completion_for_install
+    "modules", required=False, nargs=-1, shell_complete=completion_for_install
 )
 @click.option("--py", is_flag=True)
 @click.option("-r", "--requirement")

--- a/circup.py
+++ b/circup.py
@@ -385,6 +385,21 @@ def clean_library_name(assumed_library_name):
     return assumed_library_name
 
 
+def completion_for_install(ctx, args, incomplete):
+    """
+    Returns the list of available modules for the command line tab-completion
+    with the ``circup install`` command.
+    """
+    # pylint: disable=unused-argument
+    available_modules = get_bundle_versions()
+    module_names = {m.replace(".py", "") for m in available_modules}
+    # remove modules already listed (no other arg should be a module name)
+    module_names = module_names - set(args)
+    if incomplete:
+        module_names = [name for name in module_names if name.startswith(incomplete)]
+    return module_names
+
+
 def ensure_latest_bundle(bundle):
     """
     Ensure that there's a copy of the latest library bundle available so circup
@@ -1102,7 +1117,9 @@ def list(ctx):  # pragma: no cover
 
 
 @main.command()
-@click.argument("modules", required=False, nargs=-1)
+@click.argument(
+    "modules", required=False, nargs=-1, autocompletion=completion_for_install
+)
 @click.option("--py", is_flag=True)
 @click.option("-r", "--requirement")
 @click.pass_context

--- a/circup.py
+++ b/circup.py
@@ -397,7 +397,7 @@ def completion_for_install(ctx, args, incomplete):
     module_names = module_names - set(args)
     if incomplete:
         module_names = [name for name in module_names if name.startswith(incomplete)]
-    return module_names
+    return sorted(module_names)
 
 
 def ensure_latest_bundle(bundle):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ black==19.3b0
 bleach==3.3.0
 certifi==2019.6.16
 chardet==3.0.4
-Click>=7.0
+Click>=8.0
 coverage==4.5.4
 docutils==0.15.2
 idna==2.8

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
 
 install_requires = [
     "semver~=2.13",
-    "Click>=7.0",
+    "Click>=8.0",
     "appdirs>=1.4.3",
     "requests>=2.22.0",
 ]


### PR DESCRIPTION
This PR adds module names completion for the install command using [click's completion feature](https://click.palletsprojects.com/en/7.x/bashcomplete/).
I installed the completion using the "Activation Script" method, and it works quite well, if a little slowly.

`circup install n`+tab -> `circup install neopixel` (+tab: offers `neopixel` and `neopixel_spi` completions)
`circup install a` + tab -> `circup install adafruit_` + m a g + tab -> `circup install adafruit_magtag `
