### PR TITLE
adding circuitpython org bundle

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -49,8 +49,10 @@ CPY_VERSION = ""
 BUNDLE_ADAFRUIT = "adafruit/Adafruit_CircuitPython_Bundle"
 #: Community bundle repository
 BUNDLE_COMMUNITY = "adafruit/CircuitPython_Community_Bundle"
+#: CircuitPython Organization bundle repository
+BUNDLE_CIRCUITPYTHON_ORG = "circuitpython/CircuitPython_Org_Bundle"
 #: Default bundle repository list
-BUNDLES_DEFAULT_LIST = [BUNDLE_ADAFRUIT, BUNDLE_COMMUNITY]
+BUNDLES_DEFAULT_LIST = [BUNDLE_ADAFRUIT, BUNDLE_COMMUNITY, BUNDLE_CIRCUITPYTHON_ORG]
 #: Module formats list (and the other form used in github files)
 PLATFORMS = {"py": "py", "6mpy": "6.x-mpy", "7mpy": "7.x-mpy"}
 


### PR DESCRIPTION
This adds the CircuitPython org bundle to the list that circup will check for installing libraries.

I tested locally by running:
```
python circup.py install displayio_annotation
```

which did successfully install the annotation library on my device.