### PR TITLE
fix Pimoroni LTR559 is not a known CircuitPython library

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -396,6 +396,7 @@ def clean_library_name(assumed_library_name):
         "adafruit_neopixel": "neopixel",
         "adafruit_sd": "adafruit_sdcard",
         "adafruit_simpleio": "simpleio",
+        "pimoroni_ltr559": "pimoroni_circuitpython_ltr559",
     }
     if "circuitpython" in assumed_library_name:
         # convert repo or pypi name to common library name


### PR DESCRIPTION
added Pimoroni LTR559 library to the not_standard_names dictionary.

```
user@machine:~/repos/circup $ python3 ./circup.py --path /tmp/circuitpython show | grep ltr559
pimoroni_circuitpython_ltr559
```

```
user@machine:~/repos/circup $ python3 ./circup.py --path /tmp/circuitpython install pimoroni_circuitpython_ltr559
Found device at /tmp/circuitpython, running CircuitPython 6.3.0.
Searching for dependencies for: ['pimoroni_circuitpython_ltr559']
WARNING:
	pimoroni_ltr559 is not a known CircuitPython library.
Ready to install: []
```

Post addition:
```
user@machine:~/repos/circup $ python3 ./circup.py --path /tmp/circuitpython install pimoroni_circuitpython_ltr559
Found device at /tmp/circuitpython, running CircuitPython 6.3.0.
Searching for dependencies for: ['pimoroni_circuitpython_ltr559']
Ready to install: ['adafruit_bus_device', 'adafruit_register', 'pimoroni_circuitpython_ltr559']

Installed 'adafruit_bus_device'.
Installed 'adafruit_register'.
Installed 'pimoroni_circuitpython_ltr559'.
```