### PR TITLE
Display the URL to update Circuitpython

### DIFF
--- a/circup.py
+++ b/circup.py
@@ -96,12 +96,12 @@ class Bundle:
         bundle_id = bundle_id.lower().replace("_", "-")
         self.key = repo
         #
-        self.url = "https://github.com/" + repo + "/releases"
+        self.url = "https://github.com/" + repo
         self.basename = bundle_id + "-{platform}-{tag}"
         self.urlzip = self.basename + ".zip"
         self.dir = os.path.join(DATA_DIR, vendor, bundle_id + "-{platform}")
         self.zip = os.path.join(DATA_DIR, bundle_id + "-{platform}.zip")
-        self.url_format = self.url + "/download/{tag}/" + self.urlzip
+        self.url_format = self.url + "/releases/download/{tag}/" + self.urlzip
         # tag
         self._current = None
         self._latest = None
@@ -170,7 +170,7 @@ class Bundle:
         :return: The most recent tag value for the project.
         """
         if self._latest is None:
-            self._latest = get_latest_release_from_url(self.url + "/latest")
+            self._latest = get_latest_release_from_url(self.url + "/releases/latest")
         return self._latest
 
     def __repr__(self):

--- a/circup.py
+++ b/circup.py
@@ -1175,7 +1175,7 @@ def list(ctx):  # pragma: no cover
     "modules", required=False, nargs=-1, shell_complete=completion_for_install
 )
 @click.option("--py", is_flag=True)
-@click.option("-r", "--requirement")
+@click.option("-r", "--requirement", type=click.Path(exists=True, dir_okay=False))
 @click.option("--auto/--no-auto", "-a/-A")
 @click.option("--auto-file", default="code.py")
 @click.pass_context
@@ -1198,8 +1198,8 @@ def install(ctx, modules, py, requirement, auto, auto_file):  # pragma: no cover
     for module, metadata in available_modules.items():
         mod_names[module.replace(".py", "").lower()] = metadata
     if requirement:
-        cwd = os.path.abspath(os.getcwd())
-        requirements_txt = open(cwd + "/" + requirement, "r").read()
+        with open(requirement, "r") as fp:
+            requirements_txt = fp.read()
         requested_installs = libraries_from_requirements(requirements_txt)
     elif auto:
         auto_file = os.path.join(ctx.obj["DEVICE_PATH"], auto_file)

--- a/circup.py
+++ b/circup.py
@@ -1234,6 +1234,7 @@ def show(match):  # pragma: no cover
     available_modules = get_bundle_versions(get_bundles_list())
     module_names = sorted([m.replace(".py", "") for m in available_modules])
     if match is not None:
+        match = match.lower()
         module_names = [m for m in module_names if match in m]
     click.echo("\n".join(module_names))
 

--- a/circup.py
+++ b/circup.py
@@ -654,8 +654,8 @@ def get_bundle(bundle, tag):
     :param str tag: The GIT tag to use to download the bundle.
     """
     click.echo("Downloading latest version for {}.\n".format(bundle.key))
-    for platform in PLATFORMS:
-        url = bundle.url_format.format(platform=PLATFORMS[platform], tag=tag)
+    for platform, github_string in PLATFORMS.items():
+        url = bundle.url_format.format(platform=github_string, tag=tag)
         logger.info("Downloading bundle: %s", url)
         r = requests.get(url, stream=True)
         # pylint: disable=no-member
@@ -722,18 +722,36 @@ def get_bundles_list():
 def get_circuitpython_version(device_path):
     """
     Returns the version number of CircuitPython running on the board connected
-    via ``device_path``. This is obtained from the ``boot_out.txt`` file on the
-    device, whose content will start with something like this::
+    via ``device_path``, along with the board ID. This is obtained from the
+    ``boot_out.txt`` file on the device, whose first line will start with
+    something like this::
 
         Adafruit CircuitPython 4.1.0 on 2019-08-02;
 
+    While the second line is::
+
+        Board ID:raspberry_pi_pico
+
     :param str device_path: The path to the connected board.
-    :return: The version string for CircuitPython running on the connected
-             board.
+    :return: A tuple with the version string for CircuitPython and the board ID string.
     """
-    with open(os.path.join(device_path, "boot_out.txt")) as boot:
-        circuit_python, _ = boot.read().split(";")
-    return circuit_python.split(" ")[-3]
+    try:
+        with open(os.path.join(device_path, "boot_out.txt")) as boot:
+            version_line = boot.readline()
+            circuit_python = version_line.split(";")[0].split(" ")[-3]
+            board_line = boot.readline()
+            if board_line.startswith("Board ID:"):
+                board_id = board_line[9:].strip()
+            else:
+                board_id = ""
+    except FileNotFoundError:
+        click.secho(
+            "Missing file boot_out.txt on the device: wrong path or drive corrupted.",
+            fg="red",
+        )
+        logger.error("boot_out.txt not found.")
+        sys.exit(1)
+    return (circuit_python, board_id)
 
 
 def get_dependencies(*requested_libraries, mod_names, to_install=()):
@@ -1059,7 +1077,7 @@ def main(ctx, verbose, path):  # pragma: no cover
         click.secho("Could not find a connected CircuitPython device.", fg="red")
         sys.exit(1)
     else:
-        CPY_VERSION = get_circuitpython_version(device_path)
+        CPY_VERSION, board_id = get_circuitpython_version(device_path)
         click.echo(
             "Found device at {}, running CircuitPython {}.".format(
                 device_path, CPY_VERSION
@@ -1073,6 +1091,11 @@ def main(ctx, verbose, path):  # pragma: no cover
                 ),
                 fg="green",
             )
+            if board_id:
+                url_download = f"https://circuitpython.org/board/{board_id}"
+            else:
+                url_download = "https://circuitpython.org/downloads"
+            click.secho("Get it here: {}".format(url_download), fg="green")
     except ValueError as ex:
         logger.warning("CircuitPython has incorrect semver value.")
         logger.warning(ex)

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -614,14 +614,22 @@ def test_get_circuitpython_version():
     Given valid content of a boot_out.txt file on a connected device, return
     the version number of CircuitPython running on the board.
     """
-    data = (
+    device_path = "device"
+    data_no_id = (
         "Adafruit CircuitPython 4.1.0 on 2019-08-02; "
         "Adafruit CircuitPlayground Express with samd21g18"
     )
-    mock_open = mock.mock_open(read_data=data)
-    device_path = "device"
-    with mock.patch("builtins.open", mock_open):
-        assert circup.get_circuitpython_version(device_path) == "4.1.0"
+    with mock.patch("builtins.open", mock.mock_open(read_data=data_no_id)) as mock_open:
+        assert circup.get_circuitpython_version(device_path) == ("4.1.0", "")
+        mock_open.assert_called_once_with(os.path.join(device_path, "boot_out.txt"))
+    data_with_id = data_no_id + "\r\n" "Board ID:this_is_a_board"
+    with mock.patch(
+        "builtins.open", mock.mock_open(read_data=data_with_id)
+    ) as mock_open:
+        assert circup.get_circuitpython_version(device_path) == (
+            "4.1.0",
+            "this_is_a_board",
+        )
         mock_open.assert_called_once_with(os.path.join(device_path, "boot_out.txt"))
 
 

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -56,7 +56,7 @@ def test_Bundle_init():
     assert repr(bundle) == repr(
         {
             "key": TEST_BUNDLE_NAME,
-            "url": "https://github.com/" + TEST_BUNDLE_NAME + "/releases",
+            "url": "https://github.com/" + TEST_BUNDLE_NAME,
             "urlzip": "adafruit-circuitpython-bundle-{platform}-{tag}.zip",
             "dir": "DATA_DIR/adafruit/adafruit-circuitpython-bundle-{platform}",
             "zip": "DATA_DIR/adafruit-circuitpython-bundle-{platform}.zip",


### PR DESCRIPTION
If there is an update to CP available, display the URL to circuitpython.org, using the Board ID if available.

Note that until 7.0.0 reaches stable, the "latest" is still 6.3.0, so to test you have to downgrade to an earlier version (which won't include the Board ID).
```py
Found device at /Volumes/CIRCUITPY, running CircuitPython 6.2.0.
A newer version of CircuitPython (6.3.0) is available.
Get it here: https://circuitpython.org/downloads
```
Or use a boot_out.txt from the latest build with a fake version number.
```py
Found device at /Volumes/CIRCUITPY, running CircuitPython 6.2.0.
A newer version of CircuitPython (6.3.0) is available.
Get it here: https://circuitpython.org/board/raspberry_pi_pico
```

A few small things coming with it too:
- Silence pylint's new(?) consider-using-dict-items warning.
- "install --requirement" allows any path and checks it exists with click.
- "show *match*" forces lower case matching (install already did).
