### PR TITLE
Add commands for a local list of 3rd party bundles

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -728,20 +728,22 @@ def get_bundle_versions(bundles_list, avoid_download=False):
 
 def get_bundles_dict():
     """
-    Retrieve the dict from BUNDLE_CONFIG_FILE (JSON).
+    Retrieve the dictionary from BUNDLE_CONFIG_FILE (JSON).
     Put the local dictionary in front, so it gets priority.
+    It's a dictionary of bundle string identifiers.
 
-    :return: Raw dictionary from the built-in config file.
+    :return: Combined dictionaries from the config files.
     """
     bundle_dict = get_bundles_local_dict()
     try:
         with open(BUNDLE_CONFIG_OVERWRITE) as bundle_config_json:
             bundle_config = json.load(bundle_config_json)
-        bundle_dict.update(bundle_config)
     except (FileNotFoundError, json.decoder.JSONDecodeError):
         with open(BUNDLE_CONFIG_FILE) as bundle_config_json:
             bundle_config = json.load(bundle_config_json)
-        bundle_dict.update(bundle_config)
+    for name, bundle in bundle_config.items():
+        if bundle not in bundle_dict.values():
+            bundle_dict[name] = bundle
     return bundle_dict
 
 

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1464,6 +1464,8 @@ def bundle_add(bundle):
     bundles_dict = get_bundles_local_dict()
     modified = False
     for bun in bundle:
+        # cleanup in case seombody pastes the URL to the repo/releases
+        bun = re.sub(r"https?://github.com/([^/]+/[^/]+)(/.*)?", r"\1", bun)
         if bun in bundles_dict.values():
             click.secho("Bundle already in list.", fg="yellow")
             click.secho("    " + bun, fg="yellow")
@@ -1472,7 +1474,7 @@ def bundle_add(bundle):
             bb = Bundle(bun)
         except ValueError:
             click.secho(
-                "Bundle string invalid, expecting: `user/repository` from the github URL.",
+                "Bundle string invalid, expecting github URL or `user/repository` string.",
                 fg="red",
             )
             click.secho("    " + bun, fg="red")
@@ -1511,6 +1513,8 @@ def bundle_remove(bundle):
     bundles_dict = get_bundles_local_dict()
     modified = False
     for bun in bundle:
+        # cleanup in case seombody pastes the URL to the repo/releases
+        bun = re.sub(r"https?://github.com/([^/]+/[^/]+)(/.*)?", r"\1", bun)
         found = False
         for name, repo in list(bundles_dict.items()):
             if bun in (name, repo):

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1289,8 +1289,8 @@ def install(ctx, modules, py, requirement, auto, auto_file):  # pragma: no cover
 # pylint: enable=too-many-arguments,too-many-locals
 
 
-@click.argument("match", required=False, nargs=1)
 @main.command()
+@click.argument("match", required=False, nargs=1)
 def show(match):  # pragma: no cover
     """
     Show a list of available modules in the bundle. These are modules which
@@ -1508,10 +1508,14 @@ def bundle_add(bundle):
 
 @main.command("bundle-remove")
 @click.argument("bundle", nargs=-1)
-def bundle_remove(bundle):
+@click.option("--reset", is_flag=True, help="Remove all local bundles.")
+def bundle_remove(bundle, reset):
     """
     Remove one or more bundles from the local bundles list.
     """
+    if reset:
+        save_local_bundles({})
+        return
     bundles_dict = get_bundles_local_dict()
     modified = False
     for bun in bundle:

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1052,37 +1052,6 @@ def save_local_bundles(bundles_data):
             os.unlink(BUNDLE_CONFIG_LOCAL)
 
 
-def show_bundles_info(show_modules=False):
-    """
-    Show the list of bundles, default and local, with URL, current version
-    and latest version retrieved from the web.
-    """
-    locals = get_bundles_local_dict().values()
-    bundles = get_bundles_list()
-    available_modules = get_bundle_versions(bundles)
-
-    def show_this(bundle_list):
-        for bundle in bundle_list:
-            click.secho(bundle.key, fg="green")
-            click.echo("    " + bundle.url)
-            click.echo("    current = " + bundle.current_tag)
-            click.echo("     latest = " + bundle.latest_tag)
-            if show_modules:
-                click.echo("Modules:")
-                for name, mod in sorted(available_modules.items()):
-                    if mod["bundle"] == bundle:
-                        click.echo(f"   {name} ({mod.get('__version__', '-')})")
-
-    list_buitlins = [x for x in bundles if x.key not in locals]
-    if list_buitlins:
-        click.secho("Built-in Bundles Information:", fg="yellow")
-        show_this(list_buitlins)
-    list_locals = [x for x in bundles if x.key in locals]
-    if list_locals:
-        click.secho("Local Bundles Information:", fg="yellow")
-        show_this(list_locals)
-
-
 def tags_data_load():
     """
     Load the list of the version tags of the bundles on disk.
@@ -1454,9 +1423,33 @@ def update(ctx, all):  # pragma: no cover
 @click.option("--modules", is_flag=True, help="List all the modules per bundle.")
 def bundle_show(modules):
     """
-    Show out the list of bundles, their URLs and version.
+    Show the list of bundles, default and local, with URL, current version
+    and latest version retrieved from the web.
     """
-    show_bundles_info(modules)
+    locals = get_bundles_local_dict().values()
+    bundles = get_bundles_list()
+    available_modules = get_bundle_versions(bundles)
+
+    def show_this(bundle_list):
+        for bundle in bundle_list:
+            click.secho(bundle.key, fg="green")
+            click.echo("    " + bundle.url)
+            click.echo("    current = " + bundle.current_tag)
+            click.echo("     latest = " + bundle.latest_tag)
+            if modules:
+                click.echo("Modules:")
+                for name, mod in sorted(available_modules.items()):
+                    if mod["bundle"] == bundle:
+                        click.echo(f"   {name} ({mod.get('__version__', '-')})")
+
+    list_buitlins = [x for x in bundles if x.key not in locals]
+    if list_buitlins:
+        click.secho("Built-in Bundles Information:", fg="yellow")
+        show_this(list_buitlins)
+    list_locals = [x for x in bundles if x.key in locals]
+    if list_locals:
+        click.secho("Local Bundles Information:", fg="yellow")
+        show_this(list_locals)
 
 
 @main.command("bundle-add")

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1432,26 +1432,18 @@ def bundle_show(modules):
     bundles = get_bundles_list()
     available_modules = get_bundle_versions(bundles)
 
-    def show_this(bundle_list):
-        for bundle in bundle_list:
+    for bundle in bundles:
+        if bundle.key in locals:
+            click.secho(bundle.key, fg="yellow")
+        else:
             click.secho(bundle.key, fg="green")
-            click.echo("    " + bundle.url)
-            click.echo("    current = " + bundle.current_tag)
-            click.echo("     latest = " + bundle.latest_tag)
-            if modules:
-                click.echo("Modules:")
-                for name, mod in sorted(available_modules.items()):
-                    if mod["bundle"] == bundle:
-                        click.echo(f"   {name} ({mod.get('__version__', '-')})")
-
-    list_buitlins = [x for x in bundles if x.key not in locals]
-    if list_buitlins:
-        click.secho("Built-in Bundles Information:", fg="yellow")
-        show_this(list_buitlins)
-    list_locals = [x for x in bundles if x.key in locals]
-    if list_locals:
-        click.secho("Local Bundles Information:", fg="yellow")
-        show_this(list_locals)
+        click.echo("    " + bundle.url)
+        click.echo("    version = " + bundle.current_tag)
+        if modules:
+            click.echo("Modules:")
+            for name, mod in sorted(available_modules.items()):
+                if mod["bundle"] == bundle:
+                    click.echo(f"   {name} ({mod.get('__version__', '-')})")
 
 
 @main.command("bundle-add")

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -34,8 +34,10 @@ DATA_DIR = appdirs.user_data_dir(appname="circup", appauthor="adafruit")
 BUNDLE_CONFIG_FILE = pkg_resources.resource_filename(
     "circup", "config/bundle_config.json"
 )
+#: Overwrite the bundles list with this file (only done manually)
+BUNDLE_CONFIG_OVERWRITE = os.path.join(DATA_DIR, "bundle_config.json")
 #: The path to the JSON file containing the local list of bundles.
-BUNDLE_CONFIG_LOCAL = os.path.join(DATA_DIR, "bundle_config.json")
+BUNDLE_CONFIG_LOCAL = os.path.join(DATA_DIR, "bundle_config_local.json")
 #: The path to the JSON file containing the metadata about the bundles.
 BUNDLE_DATA = os.path.join(DATA_DIR, "circup.json")
 #: The directory containing the utility's log file.
@@ -732,9 +734,14 @@ def get_bundles_dict():
     :return: Raw dictionary from the built-in config file.
     """
     bundle_dict = get_bundles_local_dict()
-    with open(BUNDLE_CONFIG_FILE) as bundle_config_json:
-        bundle_config = json.load(bundle_config_json)
-    bundle_dict.update(bundle_config)
+    try:
+        with open(BUNDLE_CONFIG_OVERWRITE) as bundle_config_json:
+            bundle_config = json.load(bundle_config_json)
+        bundle_dict.update(bundle_config)
+    except (FileNotFoundError, json.decoder.JSONDecodeError):
+        with open(BUNDLE_CONFIG_FILE) as bundle_config_json:
+            bundle_config = json.load(bundle_config_json)
+        bundle_dict.update(bundle_config)
     return bundle_dict
 
 

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1508,13 +1508,14 @@ def bundle_remove(bundle, reset):
     if reset:
         save_local_bundles({})
         return
-    bundles_dict = get_bundles_local_dict()
+    bundle_config = list(get_bundles_dict().values())
+    bundles_local_dict = get_bundles_local_dict()
     modified = False
     for bun in bundle:
         # cleanup in case seombody pastes the URL to the repo/releases
         bun = re.sub(r"https?://github.com/([^/]+/[^/]+)(/.*)?", r"\1", bun)
         found = False
-        for name, repo in list(bundles_dict.items()):
+        for name, repo in list(bundles_local_dict.items()):
             if bun in (name, repo):
                 found = True
                 click.secho(f"Bundle {repo}")
@@ -1523,14 +1524,18 @@ def bundle_remove(bundle, reset):
                     click.secho("Removing the bundle from the local list", fg="yellow")
                     click.secho(f"    {bun}", fg="yellow")
                     modified = True
-                    del bundles_dict[name]
+                    del bundles_local_dict[name]
         if not found:
-            click.secho(
-                "Bundle not found in the local list, nothing removed:" "\n    " + bun,
-                fg="red",
-            )
+            if bun in bundle_config:
+                click.secho("Cannot remove built-in module:" "\n    " + bun, fg="red")
+            else:
+                click.secho(
+                    "Bundle not found in the local list, nothing removed:"
+                    "\n    " + bun,
+                    fg="red",
+                )
     if modified:
-        save_local_bundles(bundles_dict)
+        save_local_bundles(bundles_local_dict)
 
 
 # Allows execution via `python -m circup ...`

--- a/tests/test_bundle_config_local.json
+++ b/tests/test_bundle_config_local.json
@@ -1,0 +1,3 @@
+{
+    "local_bundle": "Neradoc/Circuitpython_Keyboard_Layouts"
+}

--- a/tests/test_bundle_config_local.json.license
+++ b/tests/test_bundle_config_local.json.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2021 Neradoc NeraOnGit@ri1.fr
+#
+# SPDX-License-Identifier: MIT

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -40,8 +40,12 @@ import circup
 
 TEST_BUNDLE_CONFIG_JSON = "tests/test_bundle_config.json"
 with open(TEST_BUNDLE_CONFIG_JSON) as tbc:
-    test_bundle_data = json.load(tbc)
-TEST_BUNDLE_NAME = test_bundle_data["test_bundle"]
+    TEST_BUNDLE_DATA = json.load(tbc)
+TEST_BUNDLE_NAME = TEST_BUNDLE_DATA["test_bundle"]
+
+TEST_BUNDLE_CONFIG_LOCAL_JSON = "tests/test_bundle_config_local.json"
+with open(TEST_BUNDLE_CONFIG_LOCAL_JSON) as tbc:
+    TEST_BUNDLE_LOCAL_DATA = json.load(tbc)
 
 
 def test_Bundle_init():
@@ -120,14 +124,87 @@ def test_Bundle_latest_tag():
         assert bundle.latest_tag == "BESTESTTAG"
 
 
+def test_get_bundles_dict():
+    """
+    Check we are getting the bundles list from BUNDLE_CONFIG_FILE.
+    """
+    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
+        "circup.BUNDLE_CONFIG_LOCAL", ""
+    ):
+        bundles_dict = circup.get_bundles_dict()
+        assert bundles_dict == TEST_BUNDLE_DATA
+
+    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
+        "circup.BUNDLE_CONFIG_LOCAL", TEST_BUNDLE_CONFIG_LOCAL_JSON
+    ):
+        bundles_dict = circup.get_bundles_dict()
+        expected_dict = {**TEST_BUNDLE_LOCAL_DATA, **TEST_BUNDLE_DATA}
+        assert bundles_dict == expected_dict
+
+
+def test_get_bundles_local_dict():
+    """
+    Check we are getting the bundles list from BUNDLE_CONFIG_LOCAL.
+    """
+    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
+        "circup.BUNDLE_CONFIG_LOCAL", ""
+    ):
+        bundles_dict = circup.get_bundles_dict()
+        assert bundles_dict == TEST_BUNDLE_DATA
+
+    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
+        "circup.BUNDLE_CONFIG_LOCAL", TEST_BUNDLE_CONFIG_LOCAL_JSON
+    ):
+        bundles_dict = circup.get_bundles_dict()
+        expected_dict = {**TEST_BUNDLE_LOCAL_DATA, **TEST_BUNDLE_DATA}
+        assert bundles_dict == expected_dict
+
+
 def test_get_bundles_list():
     """
     Check we are getting the bundles list from BUNDLE_CONFIG_FILE.
     """
-    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON):
+    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
+        "circup.BUNDLE_CONFIG_LOCAL", ""
+    ):
         bundles_list = circup.get_bundles_list()
         bundle = circup.Bundle(TEST_BUNDLE_NAME)
         assert repr(bundles_list) == repr([bundle])
+
+
+def test_save_local_bundles():
+    """
+    Pretend to save local bundles.
+    """
+    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
+        "circup.BUNDLE_CONFIG_LOCAL", ""
+    ), mock.patch("circup.os.unlink") as mock_unlink, mock.patch(
+        "circup.json.dump"
+    ) as mock_dump, mock.patch(
+        "circup.json.load", return_value=TEST_BUNDLE_DATA
+    ), mock.patch(
+        "circup.open", mock.mock_open()
+    ) as mock_open:
+        final_data = {**TEST_BUNDLE_DATA, **TEST_BUNDLE_LOCAL_DATA}
+        circup.save_local_bundles(final_data)
+        mock_dump.assert_called_once_with(final_data, mock_open())
+        mock_unlink.assert_not_called()
+
+
+def test_save_local_bundles_reset():
+    """
+    Pretend to reset the local bundles.
+    """
+    with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
+        "circup.BUNDLE_CONFIG_LOCAL", "test/NOTEXISTS"
+    ), mock.patch("circup.os.unlink") as mock_unlink, mock.patch(
+        "circup.json.load", return_value=TEST_BUNDLE_DATA
+    ), mock.patch(
+        "circup.open", mock.mock_open()
+    ) as mock_open:
+        circup.save_local_bundles({})
+        mock_open().write.assert_not_called()
+        mock_unlink.assert_called_once_with("test/NOTEXISTS")
 
 
 def test_Module_init_file_module():

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -197,7 +197,9 @@ def test_save_local_bundles_reset():
     """
     with mock.patch("circup.BUNDLE_CONFIG_FILE", TEST_BUNDLE_CONFIG_JSON), mock.patch(
         "circup.BUNDLE_CONFIG_LOCAL", "test/NOTEXISTS"
-    ), mock.patch("circup.os.unlink") as mock_unlink, mock.patch(
+    ), mock.patch("circup.os.path.isfile", return_value=True), mock.patch(
+        "circup.os.unlink"
+    ) as mock_unlink, mock.patch(
         "circup.json.load", return_value=TEST_BUNDLE_DATA
     ), mock.patch(
         "circup.open", mock.mock_open()


### PR DESCRIPTION
This adds commands to manage a local list of 3rd-party bundles.

- `bundle-show` lists (all) the bundles. `--modules` lists the modules for each bundle.
- `bundle-add "user/repo"` adds a bundle from the repository at `https://github/user/repo`. It does some level of checking that the repo exists, has a release, and the zips URLs exist. It doesn't check the content of the zips at this stage.
- `bundle-remove "user/repo"` removes a bundle from the local list. `--reset` removes them all.
- The repository URL is a valid bundle reference too.

The list is separate from the built-in bundles, which can not be removed via the commands. In case of module names clashing, local bundles have priority over the built-in ones, and are checked in the order they were added. Finer management of priorities and module disambiguation can be added if and when it's actually needed.

```
❯ circup bundle-add Neradoc/Circuitpython_Keyboard_Layouts
Added Neradoc/Circuitpython_Keyboard_Layouts
    https://github.com/Neradoc/Circuitpython_Keyboard_Layouts
```
```
❯ circup bundle-show 
Neradoc/Circuitpython_Keyboard_Layouts
    https://github.com/Neradoc/Circuitpython_Keyboard_Layouts
    version = 20210911
adafruit/Adafruit_CircuitPython_Bundle
    https://github.com/adafruit/Adafruit_CircuitPython_Bundle
    version = 20210908
adafruit/CircuitPython_Community_Bundle
    https://github.com/adafruit/CircuitPython_Community_Bundle
    version = 20210908
circuitpython/CircuitPython_Org_Bundle
    https://github.com/circuitpython/CircuitPython_Org_Bundle
    version = 0.0.3
```
```
❯ circup install keyboard_layout_win_fr 
Found device at /Volumes/CIRCUITPY, running CircuitPython 7.0.0-rc.1.
Searching for dependencies for: ['keyboard_layout_win_fr']
Ready to install: ['adafruit_hid', 'keyboard_layout', 'keyboard_layout_win_fr']

Installed 'adafruit_hid'.
Installed 'keyboard_layout'.
Installed 'keyboard_layout_win_fr'.
```
```
❯ circup bundle-remove Neradoc/Circuitpython_Keyboard_Layouts
Bundle Neradoc/Circuitpython_Keyboard_Layouts
Do you want to remove that bundle ? [y/N]: y
Removing the bundle from the local list:
    Neradoc/Circuitpython_Keyboard_Layouts
```
Bundle validation:
```
❯ circup bundle-add not_a_repository
Bundle string invalid, expecting github URL or `user/repository` string.
    not_a_repository
```
```
❯ circup bundle-add adafruit/doesnt_exist
Bundle invalid, the repository doesn't exist (404).
    adafruit/doesnt_exist
```
```
❯ circup bundle-add adafruit/circup
Bundle invalid, is the repository a valid circup bundle ?
    adafruit/circup
```

### Override the built-in

The built-in bundles can also be overridden by manually adding a `bundle_config.json` file in the application's user data directory (where the rest of the configuration is). A content of `{}` will remove all the built-in bundles.
