### PR TITLE
remove 6.x platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
       run: echo ::set-output name=repo-name::circup
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Pip install Sphinx & pre-commit
       run: |
         pip install --force-reinstall Sphinx sphinx-rtd-theme pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,3 @@ venv.bak/
 
 # emacs
 *~
-
-# Jet Brains
-.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ venv.bak/
 
 # emacs
 *~
+
+# Jet Brains
+.idea/*

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -55,7 +55,7 @@ NOT_MCU_LIBRARIES = [
 #: The version of CircuitPython found on the connected device.
 CPY_VERSION = ""
 #: Module formats list (and the other form used in github files)
-PLATFORMS = {"py": "py", "6mpy": "6.x-mpy", "7mpy": "7.x-mpy"}
+PLATFORMS = {"py": "py", "7mpy": "7.x-mpy"}
 #: Commands that do not require an attached board
 BOARDLESS_COMMANDS = ["show", "bundle-add", "bundle-remove", "bundle-show"]
 

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -94,11 +94,6 @@ def test_Bundle_lib_dir():
             "adafruit/adafruit-circuitpython-bundle-py/"
             "adafruit-circuitpython-bundle-py-TESTTAG/lib"
         )
-        assert bundle.lib_dir("6mpy") == (
-            "DATA_DIR/"
-            "adafruit/adafruit-circuitpython-bundle-6mpy/"
-            "adafruit-circuitpython-bundle-6.x-mpy-TESTTAG/lib"
-        )
         assert bundle.lib_dir("7mpy") == (
             "DATA_DIR/"
             "adafruit/adafruit-circuitpython-bundle-7mpy/"
@@ -315,7 +310,7 @@ def test_Module_mpy_mismatch():
     """
     path = os.path.join("foo", "bar", "baz", "module.mpy")
     repo = "https://github.com/adafruit/SomeLibrary.git"
-    with mock.patch("circup.CPY_VERSION", "6.1.2"):
+    with mock.patch("circup.CPY_VERSION", "7.0.0"):
         bundle = circup.Bundle(TEST_BUNDLE_NAME)
         m1 = circup.Module(path, repo, "1.2.3", "1.2.3", True, bundle, (None, None))
         m2 = circup.Module(
@@ -369,7 +364,7 @@ def test_Module_row():
     path = os.path.join("foo", "bar", "baz", "module.py")
     repo = "https://github.com/adafruit/SomeLibrary.git"
     with mock.patch("circup.os.path.isfile", return_value=True), mock.patch(
-        "circup.CPY_VERSION", "6.1.2"
+        "circup.CPY_VERSION", "7.0.0"
     ):
         m = circup.Module(path, repo, "1.2.3", None, False, bundle, (None, None))
         assert m.row == ("module", "1.2.3", "unknown", "Major Version")
@@ -935,11 +930,13 @@ def test_get_bundle():
         tag = "12345"
         bundle = circup.Bundle(TEST_BUNDLE_NAME)
         circup.get_bundle(bundle, tag)
-        assert mock_requests.get.call_count == 3
-        assert mock_open.call_count == 3
-        assert mock_shutil.rmtree.call_count == 3
-        assert mock_zipfile.ZipFile.call_count == 3
-        assert mock_zipfile.ZipFile().__enter__().extractall.call_count == 3
+        # how many bundles currently supported. i.e. 6x.mpy, 7x.mpy, py = 3 bundles
+        _bundle_count = 2
+        assert mock_requests.get.call_count == _bundle_count
+        assert mock_open.call_count == _bundle_count
+        assert mock_shutil.rmtree.call_count == _bundle_count
+        assert mock_zipfile.ZipFile.call_count == _bundle_count
+        assert mock_zipfile.ZipFile().__enter__().extractall.call_count == _bundle_count
 
 
 def test_get_bundle_network_error():


### PR DESCRIPTION
Remove 6.x from platforms so that circup will not download these bundles any more.

Resolves: #131 

Tested successfully locally by running this in the repo
```
pip install .
```
and then installing a library with:
```
circup install adafruit_io
```