### PR TITLE
Report if a newer version of circup is available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ sphinxcontrib-serializinghtml==1.1.3
 toml==0.10.0
 tqdm==4.35.0
 twine==1.13.0
+update-checker==0.18.0
 urllib3==1.26.5
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ install_requires = [
     "appdirs>=1.4.3",
     "requests>=2.22.0",
     "findimports>=2.1.0",
+    # importlib_metadata is only available for 3.7, and is not needed for 3.8 and up.
+    "importlib_metadata; python_version == '3.7'",
 ]
 
 extras_require = {


### PR DESCRIPTION
Uses `update-checker` to determine if a newer version of circup is available. Will print a message like:
```
Version 1.0.2 of circup is outdated. Version 1.0.3 was released 6 days ago.
```
Tested by hand by code modification.

Determining `circup`'s own version is not so easy. `__version__` is not correct.  Code taken from how click does it.

Q: is `requirements.txt` used at all? Should it be removed?

Fixes #135.