### PR TITLE
add platform entry for 8mpy

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -58,7 +58,7 @@ NOT_MCU_LIBRARIES = [
 #: The version of CircuitPython found on the connected device.
 CPY_VERSION = ""
 #: Module formats list (and the other form used in github files)
-PLATFORMS = {"py": "py", "7mpy": "7.x-mpy"}
+PLATFORMS = {"py": "py", "7mpy": "7.x-mpy", "8mpy": "7.x-mpy"}
 #: Commands that do not require an attached board
 BOARDLESS_COMMANDS = ["show", "bundle-add", "bundle-remove", "bundle-show"]
 


### PR DESCRIPTION
This allows circup to successfully install currently distributed library mpy files onto devices that report 8.0.0 based version strings in their boot_out.txt file such as building from main or current open PR branches. 

Tested successfully by installing a library on PyPortal Titano with a custom build from a PR:
```
Adafruit CircuitPython 8.0.0-alpha.0-2-gffc451b33-dirty on 2022-06-04; Adafruit PyPortal Titano with samd51j20
Board ID:pyportal_titano
```