### PR TITLE
fix reading __version__ and __repo__ with type annotations

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -512,7 +512,7 @@ def extract_metadata(path):
         with open(path, encoding="utf-8") as source_file:
             content = source_file.read()
         #: The regex used to extract ``__version__`` and ``__repo__`` assignments.
-        dunder_key_val = r"""(__\w+__)\s*=\s*(?:['"]|\(\s)(.+)['"]"""
+        dunder_key_val = r"""(__\w+__)(?:\s*:\s*\w+)?\s*=\s*(?:['"]|\(\s)(.+)['"]"""
         for match in re.findall(dunder_key_val, content):
             result[match[0]] = str(match[1])
         if result:


### PR DESCRIPTION
Some libraries (currently 3) now show up with this:
```py
__version__: str = "1.0.13"
__repo__: str = "https://github.com/adafruit/Adafruit_CircuitPython_AHTx0.git"
```
Circup couldn't read those, this updates the RE to skip type annotations (it's always `str` but I made it `\w`)
Before:
```
❯ circup list
...
Module          Version  Latest   Update Reason  
--------------- -------- -------- -------------- 
adafruit_ahtx0  1.0.12   unknown  Major Version  
adafruit_ticks  1.0.3    1.0.4    Minor Version  
```
After:
```
❯ circup list
...
Module          Version  Latest  Update Reason  
--------------- -------- ------- -------------- 
adafruit_ahtx0  1.0.12   1.0.13  Minor Version  
adafruit_ticks  1.0.3    1.0.4   Minor Version 
```