### PR TITLE
Update pinned importlib_metadata version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ docutils==0.15.2
 findimports==2.1.0
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.20
+importlib_metadata==4.12.0
 isort==5.9.3
 Jinja2==2.11.3
 lazy-object-proxy==1.6.0


### PR DESCRIPTION
Looks like the currently pinned version of `importlib_metadata` is incompatible with `setuptools`, so this re-pins it to a newly updated version.  Not entirely sure what the full ramifications of this are (from 0.20 to 4.12), to be honest, though it looks like, at a glance, our specific use of `importlib_metadata.version()` is unchanged between versions, from any kind of API breaking change perspective.