### PR TITLE
fix filtering all pip version strings in requirements.txt

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1058,9 +1058,8 @@ def libraries_from_requirements(requirements):
             # skip comments
             pass
         else:
-            if any(operators in line for operators in [">", "<", "="]):
-                # Remove everything after any pip style version specifiers
-                line = re.split("[<|>|=|]", line)[0]
+            # Remove everything after any pip style version specifiers
+            line = re.split("[<>=~[;]", line)[0].strip()
             libraries = libraries + (line,)
     return libraries
 


### PR DESCRIPTION
Same fix for the filter of pip requirements as in circuitpython-build-tools:
Add `~[;` to filter requirements and strip() spaces. [See here examples of valid formats](https://pip.pypa.io/en/stable/reference/requirement-specifiers/#examples).

Example offending library, `~` in the last line of: https://github.com/adafruit/Adafruit_CircuitPython_BLE/blob/d24b8325f23cc933eb1df42c37aa4bc5a8387fe2/requirements.txt#L9