### PR TITLE
Find all files in packages

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -961,8 +961,8 @@ def get_modules(path):
         result[os.path.basename(sfm).replace(".py", "").replace(".mpy", "")] = metadata
     for package_path in package_dir_mods:
         name = os.path.basename(os.path.dirname(package_path))
-        py_files = glob.glob(os.path.join(package_path, "*.py"))
-        mpy_files = glob.glob(os.path.join(package_path, "*.mpy"))
+        py_files = glob.glob(os.path.join(package_path, "**/*.py"), recursive=True)
+        mpy_files = glob.glob(os.path.join(package_path, "**/*.mpy"), recursive=True)
         all_files = py_files + mpy_files
         # default value
         result[name] = {"path": package_path, "mpy": bool(mpy_files)}


### PR DESCRIPTION
When circup looks at the board libraries it reads them all to find the version number and incompatible or invalid MPY files.
But it only looked at the first level files. This PR makes it look at all levels using the `**/` pattern and recursive glob option.

At least one library, `adafruit_displayio_layout` has no file at the first level that contain version information (only an empty init).

before
```
❯ circup freeze
Found device at /Volumes/CIRCUITPY, running CircuitPython 8.0.0-beta.6-62-g7522522a0-dirty.
adafruit_displayio_layout==None
```
after
```
❯ circup freeze
Found device at /Volumes/CIRCUITPY, running CircuitPython 8.0.0-beta.6-62-g7522522a0-dirty.
adafruit_displayio_layout==1.19.10
```