### PR TITLE
Auto install improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,12 @@ repos:
     -   id: pylint
         name: lint (code)
         types: [python]
-        exclude: "^(docs/|examples/|setup.py$)"
+        exclude: "^(docs/|examples/|setup.py$|tests/bad_python.py$)"
 -   repo: https://github.com/python/black
     rev: 22.3.0
     hooks:
-    - id: black
+    -   id: black
+        exclude: "^tests/bad_python.py$"
 -   repo: https://github.com/fsfe/reuse-tool
     rev: v0.14.0
     hooks:

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1338,7 +1338,7 @@ def install(ctx, modules, pyext, requirement, auto, auto_file):  # pragma: no co
         if auto_file is None:
             auto_file = "code.py"
         # pass a local file with "./" or "../"
-        is_relative = auto_file.startswith("." + os.sep) or auto_file.startswith(".." + os.sep)
+        is_relative = auto_file.split(os.sep)[0] in [os.path.curdir, os.path.pardir]
         if not os.path.isabs(auto_file) and not is_relative:
             auto_file = os.path.join(ctx.obj["DEVICE_PATH"], auto_file or "code.py")
         if not os.path.isfile(auto_file):

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1299,12 +1299,12 @@ def list_cli(ctx):  # pragma: no cover
     "modules", required=False, nargs=-1, shell_complete=completion_for_install
 )
 @click.option(
+    "pyext",
     "--py",
     is_flag=True,
     help="Install the .py version of the module(s) instead of the mpy version.",
 )
 @click.option(
-    "pyext",
     "-r",
     "--requirement",
     type=click.Path(exists=True, dir_okay=False),

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1298,23 +1298,32 @@ def list_cli(ctx):  # pragma: no cover
 @click.argument(
     "modules", required=False, nargs=-1, shell_complete=completion_for_install
 )
-@click.option("pyext", "--py", is_flag=True)
-@click.option("-r", "--requirement", type=click.Path(exists=True, dir_okay=False))
-@click.option("--auto/--no-auto", "-a/-A")
-@click.option("--auto-file", default=None)
+@click.option(
+    "--py",
+    is_flag=True,
+    help="Install the .py version of the module(s) instead of the mpy version.",
+)
+@click.option(
+    "pyext",
+    "-r",
+    "--requirement",
+    type=click.Path(exists=True, dir_okay=False),
+    help="specify a text file to install all modules listed in the text file."
+    " Typically requirements.txt.",
+)
+@click.option("--auto", "-a", help="Install the modules imported in code.py.")
+@click.option(
+    "--auto-file",
+    default=None,
+    help="Specify the name of a file on the board to read for auto install."
+    " Also accepts an absolute path or a local ./ path.",
+)
 @click.pass_context
 def install(ctx, modules, pyext, requirement, auto, auto_file):  # pragma: no cover
     """
     Install a named module(s) onto the device. Multiple modules
     can be installed at once by providing more than one module name, each
     separated by a space.
-
-    Option --py installs .py version of module(s).
-
-    Option -r allows specifying a text file to install all modules listed in
-    the text file.
-
-    Option -a installs based on the modules imported by code.py
     """
     # TODO: Ensure there's enough space on the device
     available_modules = get_bundle_versions(get_bundles_list())

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1338,7 +1338,7 @@ def install(ctx, modules, pyext, requirement, auto, auto_file):  # pragma: no co
         if auto_file is None:
             auto_file = "code.py"
         # pass a local file with "./" or "../"
-        is_relative = auto_file[:2] in ("." + os.sep, "..")
+        is_relative = auto_file.startswith("." + os.sep) or auto_file.startswith(".." + os.sep)
         if not os.path.isabs(auto_file) and not is_relative:
             auto_file = os.path.join(ctx.obj["DEVICE_PATH"], auto_file or "code.py")
         if not os.path.isfile(auto_file):

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1328,7 +1328,9 @@ def install(ctx, modules, pyext, requirement, auto, auto_file):  # pragma: no co
     elif auto or auto_file:
         if auto_file is None:
             auto_file = "code.py"
-        if not os.path.isabs(auto_file) and not auto_file[:2] == "./":
+        # pass a local file with "./" or "../"
+        is_relative = auto_file[:2] in ("." + os.sep, "..")
+        if not os.path.isabs(auto_file) and not is_relative:
             auto_file = os.path.join(ctx.obj["DEVICE_PATH"], auto_file or "code.py")
         if not os.path.isfile(auto_file):
             click.secho(f"Auto file not found: {auto_file}", fg="red")

--- a/tests/bad_python.py
+++ b/tests/bad_python.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Jeff Epler for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+# pylint: disable=all
+
+if True:

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -1030,3 +1030,12 @@ def test_libraries_from_imports():
         "adafruit_esp32spi",
         "adafruit_hid",
     ]
+
+
+def test_libraries_from_imports_bad():
+    """Ensure that we catch an import error"""
+    TEST_BUNDLE_MODULES = {"one.py": {}, "two.py": {}, "three.py": {}}
+    runner = CliRunner()
+    with mock.patch("circup.get_bundle_versions", return_value=TEST_BUNDLE_MODULES):
+        result = runner.invoke(circup.install, ["--auto-file", "./tests/bad_python.py"])
+    assert result.exit_code == 2


### PR DESCRIPTION
- The install `--auto-file` option now implies `--auto`, so we don't have to put both.
- Auto file accepts absolute paths (like what you get when drag-and-dropping the file to the terminal).
- Auto file takes local relative paths starting with "./" (might not work on windows ⚠️).
- If the analyzed file has an error, it's caught and circup stops with a message instead of a stacktrace.

For example with this `test.py`:
```py
if True:
```
```
❯ circup install --auto-file /Volumes/CIRCUITPY/test.py 
Found device at /Volumes/CIRCUITPY, running CircuitPython 8.0.0-beta.6-62-g7522522a0-dirty.
Unable to read the auto file: "expected an indented block (test.py, line 1)"
```

Note: adds a bad python file for tests, which also has to be ignored in pre-commit.