### PR TITLE
add support for web workflow

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Vladimír Kotal
+#
+# SPDX-License-Identifier: Unlicense
+[settings]
+profile = black

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -647,7 +647,7 @@ def test_get_bundle_versions():
     Ensure ensure_latest_bundle is called even if lib_dir exists.
     """
     with mock.patch("circup.ensure_latest_bundle") as mock_elb, mock.patch(
-        "circup.get_modules", return_value={"ok": {"name": "ok"}}
+        "circup._get_modules_file", return_value={"ok": {"name": "ok"}}
     ) as mock_gm, mock.patch("circup.CPY_VERSION", "4.1.2"), mock.patch(
         "circup.Bundle.lib_dir", return_value="foo/bar/lib"
     ), mock.patch(
@@ -668,7 +668,7 @@ def test_get_bundle_versions_avoid_download():
     Testing both cases: lib_dir exists and lib_dir doesn't exists.
     """
     with mock.patch("circup.ensure_latest_bundle") as mock_elb, mock.patch(
-        "circup.get_modules", return_value={"ok": {"name": "ok"}}
+        "circup._get_modules_file", return_value={"ok": {"name": "ok"}}
     ) as mock_gm, mock.patch("circup.CPY_VERSION", "4.1.2"), mock.patch(
         "circup.Bundle.lib_dir", return_value="foo/bar/lib"
     ):


### PR DESCRIPTION
This change introduces the support for web workflow. I could perform only limited testing (esp. of multi-file packages) since my web workflow capable devices are all ESP32 V2's which stop listening on port 80 after single PUT/DELETE request and have to be restarted. I wanted to get this out for review, hence the prematurity. pytest of the pre-existing tests passes. I can be certainly persuaded to add web workflow specific tests.