### PR TITLE
Fix auto requiring an argument

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1311,7 +1311,9 @@ def list_cli(ctx):  # pragma: no cover
     help="specify a text file to install all modules listed in the text file."
     " Typically requirements.txt.",
 )
-@click.option("--auto", "-a", help="Install the modules imported in code.py.")
+@click.option(
+    "--auto", "-a", is_flag=True, help="Install the modules imported in code.py."
+)
 @click.option(
     "--auto-file",
     default=None,


### PR DESCRIPTION
Dunno how that slipped in through my tests, but I broke --auto:
```
❯ circup install --auto
...
Error: Option '--auto' requires an argument.
```