### PR TITLE
correctly install asyncio from requirements.txt

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -432,6 +432,7 @@ def clean_library_name(assumed_library_name):
         "adafruit_sd": "adafruit_sdcard",
         "adafruit_simpleio": "simpleio",
         "pimoroni_ltr559": "pimoroni_circuitpython_ltr559",
+        "adafruit_asyncio": "asyncio",
     }
     if "circuitpython" in assumed_library_name:
         # convert repo or pypi name to common library name

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -426,13 +426,13 @@ def clean_library_name(assumed_library_name):
     not_standard_names = {
         # Assumed Name : Actual Name
         "adafruit_adafruitio": "adafruit_io",
+        "adafruit_asyncio": "asyncio",
         "adafruit_busdevice": "adafruit_bus_device",
         "adafruit_display_button": "adafruit_button",
         "adafruit_neopixel": "neopixel",
         "adafruit_sd": "adafruit_sdcard",
         "adafruit_simpleio": "simpleio",
         "pimoroni_ltr559": "pimoroni_circuitpython_ltr559",
-        "adafruit_asyncio": "asyncio",
     }
     if "circuitpython" in assumed_library_name:
         # convert repo or pypi name to common library name


### PR DESCRIPTION
Circup currently fails to install asyncio where this is referenced in
requirements.txt as adafruit-circuitpython-asyncio. This PR adds the 
asyncio module to the "non-standard library" list


