### PR TITLE
Add board-id and cpy-version params

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1212,10 +1212,11 @@ def main(ctx, verbose, path, board_id, cpy_version):  # pragma: no cover
         click.secho("Could not find a connected CircuitPython device.", fg="red")
         sys.exit(1)
     else:
-        if board_id is not None and cpy_version is not None:
-            CPY_VERSION = cpy_version
-        else:
-            CPY_VERSION, board_id = get_circuitpython_version(device_path)
+        CPY_VERSION, board_id = (
+            get_circuitpython_version(device_path)
+            if board_id is None or cpy_version is None
+            else (cpy_version, board_id)
+        )
         click.echo(
             "Found device at {}, running CircuitPython {}.".format(
                 device_path, CPY_VERSION

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1157,12 +1157,22 @@ def tags_data_save_tag(key, tag):
     type=click.Path(exists=True, file_okay=False),
     help="Path to CircuitPython directory. Overrides automatic path detection.",
 )
+@click.option(
+    "--board-id",
+    default=None,
+    help="Manual Board ID of the CircuitPython device. If provided in combination with --cpy-version, it overrides the detected board ID.",
+)
+@click.option(
+    "--cpy-version",
+    default=None,
+    help="Manual CircuitPython version. If provided in combination with --board-id, it overrides the detected CPy version.",
+)
 @click.version_option(
     prog_name="CircUp",
     message="%(prog)s, A CircuitPython module updater. Version %(version)s",
 )
 @click.pass_context
-def main(ctx, verbose, path):  # pragma: no cover
+def main(ctx, verbose, path, board_id, cpy_version):  # pragma: no cover
     """
     A tool to manage and update libraries on a CircuitPython device.
     """
@@ -1200,7 +1210,10 @@ def main(ctx, verbose, path):  # pragma: no cover
         click.secho("Could not find a connected CircuitPython device.", fg="red")
         sys.exit(1)
     else:
-        CPY_VERSION, board_id = get_circuitpython_version(device_path)
+        if board_id is not None and cpy_version is not None:
+            CPY_VERSION = cpy_version
+        else:
+            CPY_VERSION, board_id = get_circuitpython_version(device_path)
         click.echo(
             "Found device at {}, running CircuitPython {}.".format(
                 device_path, CPY_VERSION

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1160,14 +1160,14 @@ def tags_data_save_tag(key, tag):
 @click.option(
     "--board-id",
     default=None,
-    help="Manual Board ID of the CircuitPython device. If provided in combination "  \
-         "with --cpy-version, it overrides the detected board ID.",
+    help="Manual Board ID of the CircuitPython device. If provided in combination "
+    "with --cpy-version, it overrides the detected board ID.",
 )
 @click.option(
     "--cpy-version",
     default=None,
-    help="Manual CircuitPython version. If provided in combination " \
-         "with --board-id, it overrides the detected CPy version.",
+    help="Manual CircuitPython version. If provided in combination "
+    "with --board-id, it overrides the detected CPy version.",
 )
 @click.version_option(
     prog_name="CircUp",

--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1160,12 +1160,14 @@ def tags_data_save_tag(key, tag):
 @click.option(
     "--board-id",
     default=None,
-    help="Manual Board ID of the CircuitPython device. If provided in combination with --cpy-version, it overrides the detected board ID.",
+    help="Manual Board ID of the CircuitPython device. If provided in combination "  \
+         "with --cpy-version, it overrides the detected board ID.",
 )
 @click.option(
     "--cpy-version",
     default=None,
-    help="Manual CircuitPython version. If provided in combination with --board-id, it overrides the detected CPy version.",
+    help="Manual CircuitPython version. If provided in combination " \
+         "with --board-id, it overrides the detected CPy version.",
 )
 @click.version_option(
     prog_name="CircUp",


### PR DESCRIPTION
``I added two more parameters to circup to override board_id a CPY_VERSION detection.

The motivation is the ability to manage the version of libraries in local projects on the computer's filesystem.

I maintain several dozen CircuitPython projects, and with these parameters I can easily keep all the project's libs up to date without having to keep uploading them to the development boards.

Without these parameters, it is necessary to add a boot_out.txt file to the projects to emulate the board. With these parameters, management is much more convenient.

Example:
`circup --path d:\cpy\picopad\demo1 --board-id pajenicko_picopad  --cpy-version 8.2.6 list`

Help message:

```
circup  --help
Usage: circup [OPTIONS] COMMAND [ARGS]...

  A tool to manage and update libraries on a CircuitPython device.

Options:
  --verbose           Comprehensive logging is sent to stdout.
  --path DIRECTORY    Path to CircuitPython directory. Overrides automatic
                      path detection.
  --board-id TEXT     Manual Board ID of the CircuitPython device. If provided
                      in combination with --cpy-version, it overrides the
                      detected board ID.
  --cpy-version TEXT  Manual CircuitPython version. If provided in combination
                      with --board-id, it overrides the detected CPy version.
  --version           Show the version and exit.
  --help              Show this message and exit.

Commands:
  bundle-add     Add bundles to the local bundles list, by "user/repo"...
  bundle-remove  Remove one or more bundles from the local bundles list.
  bundle-show    Show the list of bundles, default and local, with URL,...
  freeze         Output details of all the modules found on the connected...
  install        Install a named module(s) onto the device.
  list           Lists all out of date modules found on the connected...
  show           Show a list of available modules in the bundle.
  uninstall      Uninstall a named module(s) from the connected device.
  update         Update modules on the device. Use --all to automatically
                 update all modules without Major Version warnings.
```