### PR TITLE
add 9.x-support; don't give up if download fails

### DIFF
--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -858,7 +858,7 @@ def test_ensure_latest_bundle_to_update():
 def test_ensure_latest_bundle_to_update_http_error():
     """
     If an HTTP error happens during a bundle update, print a friendly
-    error message and exit 1.
+    error message, and use existing bundle.
     """
     tags_data = {TEST_BUNDLE_NAME: "12345"}
     with mock.patch("circup.Bundle.latest_tag", "54321"), mock.patch(
@@ -872,9 +872,7 @@ def test_ensure_latest_bundle_to_update_http_error():
         "circup.json"
     ) as mock_json, mock.patch(
         "circup.click.secho"
-    ) as mock_click, mock.patch(
-        "circup.sys.exit"
-    ) as mock_exit:
+    ) as mock_click:
         circup.Bundle.tags_data = dict()
         mock_json.load.return_value = tags_data
         bundle = circup.Bundle(TEST_BUNDLE_NAME)
@@ -882,7 +880,6 @@ def test_ensure_latest_bundle_to_update_http_error():
         mock_gb.assert_called_once_with(bundle, "54321")
         assert mock_json.dump.call_count == 0  # not saved.
         assert mock_click.call_count == 1  # friendly message.
-        mock_exit.assert_called_once_with(1)  # exit 1.
 
 
 def test_ensure_latest_bundle_no_update():


### PR DESCRIPTION
- Add `9.x-mpy` platform.
- Print out platform designator when downloading, e.g., `py`, `8.x-mpy`, `9.x-mpy`.
- Print "Extracting:" in front of progress bar to make it clear that's unzipping, not downloading.
- Don't give up and exit if the particular bundle can't be downloaded. Use an existing one if possible. Otherwise, circup becomes unusable when there is a missing bundle or other problem. This was motivated by the latest bundles not being built properly (due to Python 3.12 becoming available as Python 3.x in GitHub CI), causing circup to stop working.

Example of new output. The platform designators have to be on a line of their own due to when exceptions are thrown and how the progress bar works.
```
$ circup install neopixel
Found device at /media/halbert/CIRCUITPY, running CircuitPython 8.2.7.
Downloading latest bundles for adafruit/Adafruit_CircuitPython_Bundle (20231025).
py:
Extracting:  [####################################]  100%
8.x-mpy:
Extracting:  [####################################]  100%
9.x-mpy:
There was a problem downloading that platform bundle. Skipping and using existing download if available.
Downloading latest bundles for adafruit/CircuitPython_Community_Bundle (20231029).
py:
There was a problem downloading that platform bundle. Skipping and using existing download if available.
Downloading latest bundles for circuitpython/CircuitPython_Org_Bundle (0.0.3).
py:
Extracting:  [####################################]  100%
8.x-mpy:
Extracting:  [####################################]  100%
9.x-mpy:
There was a problem downloading that platform bundle. Skipping and using existing download if available.
Searching for dependencies for: ['neopixel']
Ready to install: ['adafruit_pixelbuf', 'neopixel']

'adafruit_pixelbuf' is already installed.
'neopixel' is already installed.
```