### PR TITLE
chore: bump semver to 3.0.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pytz==2019.2
 readme-renderer==24.0
 requests==2.31.0
 requests-toolbelt==0.9.1
-semver==2.13.0
+semver==3.0.1
 six==1.12.0
 snowballstemmer==1.9.0
 Sphinx==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 install_requires = [
-    "semver~=2.13",
+    "semver~=3.0",
     "Click>=8.0",
     "appdirs>=1.4.3",
     "requests>=2.22.0",


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2019 Nicholas Tollervey, written for Adafruit Industries

SPDX-License-Identifier: MIT -->

Updates requirements.txt and setup.py to reference semver for the next major release, 3.0.0

There are no code changes needed to support this as circup doesn't use any of the deprecated
features, or so it seems.  The biggest change here from what I can tell is that python 2 is no longer supported.

pytest results:

```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/james/Projects/imnotjames/circup
plugins: hypothesis-6.88.1
collected 50 items                                                                                                                                                                        

tests/test_circup.py ..................................................                                                                                                             [100%]

==================================================================================== warnings summary =====================================================================================
circup/__init__.py:23
  /home/james/Projects/imnotjames/circup/circup/__init__.py:23: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../../../../usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
../../../../../usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
../../../../../usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
../../../../../usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
../../../../../usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
../../../../../usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
../../../../../usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
  /usr/lib/python3.11/site-packages/pkg_resources/__init__.py:2871: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 50 passed, 8 warnings in 0.32s ==============================================================================
```

The warnings seem to be unrelated to this change.