### PR TITLE
add toml to dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ install_requires = [
     "appdirs>=1.4.3",
     "requests>=2.22.0",
     "findimports>=2.1.0",
+    "toml>=0.10.2",
     # importlib_metadata is only available for 3.7, and is not needed for 3.8 and up.
     "importlib_metadata; python_version == '3.7'",
     "update_checker",


### PR DESCRIPTION
resolves #191

Tested in an empty venv and with this change I'm able to use circup immediately after installing.