### PR TITLE
Fix renamed `is_valid()` method call

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -1514,7 +1514,7 @@ def update(ctx, update_all):  # pragma: no cover
                         module.device_version, module.bundle_version
                     )
                 )
-            if isinstance(module.bundle_version, str) and not VersionInfo.isvalid(
+            if isinstance(module.bundle_version, str) and not VersionInfo.is_valid(
                 module.bundle_version
             ):
                 click.secho(


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**

This change fixes a bug with the code following a change to the `semver` package which renames the `isvalid()` method to `is_valid()`. Fixes https://github.com/adafruit/circup/issues/193

- **Describe any known limitations with your change.**

n/a

- **Please run any tests or examples that can exercise your modified code.**

n/a
