### PR TITLE
Handle mpy version checking for Circuitpython 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,19 +29,21 @@ jobs:
         python3 --version
         pre-commit --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
+        show-progress: false
     - name: Library version
       run: git describe --dirty --always --tags
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
     - name: Checkout tools repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: adafruit/actions-ci-circuitpython-libs
         path: actions-ci
+        show-progress: false
     - name: Install dependencies
       # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ jobs:
   upload-pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Check For setup.py
       id: need-pypi
       run: |

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -316,7 +316,7 @@ def test_Module_mpy_mismatch():
         bundle = circup.Bundle(TEST_BUNDLE_NAME)
         m1 = circup.Module(path, repo, "1.2.3", "1.2.3", True, bundle, (None, None))
         m2 = circup.Module(
-            path, repo, "1.2.3", "1.2.3", True, bundle, ("7.0.0-alpha.1", None)
+            path, repo, "1.2.3", "1.2.3", True, bundle, ("7.0.0-alpha.1", "8.99.99")
         )
         m3 = circup.Module(
             path, repo, "1.2.3", "1.2.3", True, bundle, (None, "7.0.0-alpha.1")
@@ -592,7 +592,7 @@ def test_extract_metadata_byte_code_v7():
     result = circup.extract_metadata("tests/local_module_cp7.mpy")
     assert result["__version__"] == "1.2.3"
     assert result["mpy"] is True
-    assert result["compatibility"] == ("7.0.0-alpha.1", None)
+    assert result["compatibility"] == ("7.0.0-alpha.1", "8.99.99")
 
 
 def test_find_modules():


### PR DESCRIPTION
Fixes #165.
Fixes #196.

- Handle .mpy files with bytecode version `C\x06`. The `__version__` string is not findable in as straightforward a way because the way dictionary entries are in the .mpy has changed, so just look for the first string that looks like a version number.

Tested on 8.2.9 and 9.0.0-beta.0, including upgrading and downgrading between those versions.