### PR TITLE
Upgrade flag

### DIFF
--- a/circup/commands.py
+++ b/circup/commands.py
@@ -285,13 +285,16 @@ def list_cli(ctx):  # pragma: no cover
     "--auto", "-a", is_flag=True, help="Install the modules imported in code.py."
 )
 @click.option(
+    "--upgrade", "-u", is_flag=True, help="Upgrade modules that are already installed."
+)
+@click.option(
     "--auto-file",
     default=None,
     help="Specify the name of a file on the board to read for auto install."
     " Also accepts an absolute path or a local ./ path.",
 )
 @click.pass_context
-def install(ctx, modules, pyext, requirement, auto, auto_file):  # pragma: no cover
+def install(ctx, modules, pyext, requirement, auto, auto_file, upgrade=False):  # pragma: no cover
     """
     Install a named module(s) onto the device. Multiple modules
     can be installed at once by providing more than one module name, each
@@ -343,7 +346,7 @@ def install(ctx, modules, pyext, requirement, auto, auto_file):  # pragma: no co
         click.echo(f"Ready to install: {to_install}\n")
         for library in to_install:
             ctx.obj["backend"].install_module(
-                ctx.obj["DEVICE_PATH"], device_modules, library, pyext, mod_names
+                ctx.obj["DEVICE_PATH"], device_modules, library, pyext, mod_names, upgrade
             )
 
 

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -294,7 +294,9 @@ def list_cli(ctx):  # pragma: no cover
     " Also accepts an absolute path or a local ./ path.",
 )
 @click.pass_context
-def install(ctx, modules, pyext, requirement, auto, auto_file, upgrade=False):  # pragma: no cover
+def install(
+    ctx, modules, pyext, requirement, auto, auto_file, upgrade=False
+):  # pragma: no cover
     """
     Install a named module(s) onto the device. Multiple modules
     can be installed at once by providing more than one module name, each
@@ -346,7 +348,12 @@ def install(ctx, modules, pyext, requirement, auto, auto_file, upgrade=False):  
         click.echo(f"Ready to install: {to_install}\n")
         for library in to_install:
             ctx.obj["backend"].install_module(
-                ctx.obj["DEVICE_PATH"], device_modules, library, pyext, mod_names, upgrade
+                ctx.obj["DEVICE_PATH"],
+                device_modules,
+                library,
+                pyext,
+                mod_names,
+                upgrade,
             )
 
 

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -285,7 +285,7 @@ def list_cli(ctx):  # pragma: no cover
     "--auto", "-a", is_flag=True, help="Install the modules imported in code.py."
 )
 @click.option(
-    "--upgrade", "-u", is_flag=True, help="Upgrade modules that are already installed."
+    "--upgrade", "-U", is_flag=True, help="Upgrade modules that are already installed."
 )
 @click.option(
     "--auto-file",


### PR DESCRIPTION
resolves #209 

Adds `--upgrade` as an option for `circup install` which behaves effectively the same as pip. If this flag is passed it will remove any modules found to be installed already before installing the latest one from the bundle. If the flag is omitted the default behavior is same as today which is print out a message but do not overwrite the existing one.