### PR TITLE
Example command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,8 @@ To get help, just type the command::
       --host TEXT         Hostname or IP address of a device. Overrides automatic
                           path detection.
       --password TEXT     Password to use for authentication when --host is used.
+      --timeout INTEGER   Specify the timeout in seconds for any network
+                          operations.
       --board-id TEXT     Manual Board ID of the CircuitPython device. If provided
                           in combination with --cpy-version, it overrides the
                           detected board ID.
@@ -107,6 +109,7 @@ To get help, just type the command::
       bundle-add     Add bundles to the local bundles list, by "user/repo"...
       bundle-remove  Remove one or more bundles from the local bundles list.
       bundle-show    Show the list of bundles, default and local, with URL,...
+      example        Copy named example(s) from a bundle onto the device.
       freeze         Output details of all the modules found on the connected...
       install        Install a named module(s) onto the device.
       list           Lists all out of date modules found on the connected...

--- a/circup/backends.py
+++ b/circup/backends.py
@@ -270,6 +270,8 @@ class WebBackend(Backend):
         """
         Install file to device using web workflow.
         :param source source file.
+        :param location the location on the device to copy the source
+          directory in to. If omitted is CIRCUITPY/lib/ used.
         """
         file_name = source.split(os.path.sep)
         file_name = file_name[-2] if file_name[-1] == "" else file_name[-1]
@@ -291,6 +293,8 @@ class WebBackend(Backend):
         """
         Install directory to device using web workflow.
         :param source source directory.
+        :param location the location on the device to copy the source
+          directory in to. If omitted is CIRCUITPY/lib/ used.
         """
         mod_name = source.split(os.path.sep)
         mod_name = mod_name[-2] if mod_name[-1] == "" else mod_name[-1]
@@ -761,7 +765,6 @@ class DiskBackend(Backend):
     def install_module_mpy(self, bundle, metadata):
         """
         :param bundle library bundle.
-        :param library_path library path
         :param metadata dictionary.
         """
         module_name = os.path.basename(metadata["path"]).replace(".py", ".mpy")
@@ -790,8 +793,9 @@ class DiskBackend(Backend):
     # pylint: enable=too-many-locals,too-many-branches
     def install_module_py(self, metadata, location=None):
         """
-        :param library_path library path
         :param metadata dictionary.
+        :param location the location on the device to copy the py module to.
+          If omitted is CIRCUITPY/lib/ used.
         """
         if location is None:
             location = self.library_path

--- a/circup/backends.py
+++ b/circup/backends.py
@@ -763,21 +763,25 @@ class DiskBackend(Backend):
             raise IOError("Cannot find compiled version of module.")
 
     # pylint: enable=too-many-locals,too-many-branches
-    def _install_module_py(self, metadata):
+    def _install_module_py(self, metadata, location=None):
         """
         :param library_path library path
         :param metadata dictionary.
         """
+        if location is None:
+            location = self.library_path
+        else:
+            location = os.path.join(self.device_location, location)
 
         source_path = metadata["path"]  # Path to Python source version.
         if os.path.isdir(source_path):
             target = os.path.basename(os.path.dirname(source_path))
-            target_path = os.path.join(self.library_path, target)
+            target_path = os.path.join(location, target)
             # Copy the directory.
             shutil.copytree(source_path, target_path)
         else:
             target = os.path.basename(source_path)
-            target_path = os.path.join(self.library_path, target)
+            target_path = os.path.join(location, target)
             # Copy file.
             shutil.copyfile(source_path, target_path)
 

--- a/circup/bundle.py
+++ b/circup/bundle.py
@@ -61,6 +61,20 @@ class Bundle:
             "lib",
         )
 
+    def examples_dir(self, platform):
+        """
+        This bundle's examples directory for the platform.
+
+        :param str platform: The platform identifier (py/6mpy/...).
+        :return: The path to the examples directory for the platform.
+        """
+        tag = self.current_tag
+        return os.path.join(
+            self.dir.format(platform=platform),
+            self.basename.format(platform=PLATFORMS[platform], tag=tag),
+            "examples",
+        )
+
     def requirements_for(self, library_name, toml_file=False):
         """
         The requirements file for this library.

--- a/circup/command_utils.py
+++ b/circup/command_utils.py
@@ -98,16 +98,8 @@ def completion_for_example(ctx, param, incomplete):
     Returns the list of available modules for the command line tab-completion
     with the ``circup example`` command.
     """
-    # pylint: disable=unused-argument
-    # available_modules = get_bundle_versions(get_bundles_list(), avoid_download=True)
-    # module_names = {m.replace(".py", "") for m in available_modules}
-    # if incomplete:
-    #     module_names = [name for name in module_names if name.startswith(incomplete)]
-    # return sorted(module_names)
-
+    # pylint: disable=unused-argument, consider-iterating-dictionary
     available_examples = get_bundle_examples(get_bundles_list(), avoid_download=True)
-    # with open("tmp1.py", "w") as f:
-    #     f.write(f"data = {str(available_examples)}")
 
     matching_examples = [
         example_path
@@ -325,6 +317,7 @@ def get_bundle_examples(bundles_list, avoid_download=False):
     :return: A dictionary of metadata about the examples available in the
              library bundle.
     """
+    # pylint: disable=too-many-nested-blocks
     all_the_examples = dict()
 
     try:
@@ -332,24 +325,8 @@ def get_bundle_examples(bundles_list, avoid_download=False):
             if not avoid_download or not os.path.isdir(bundle.lib_dir("py")):
                 ensure_latest_bundle(bundle)
             path = bundle.examples_dir("py")
-            # with open("path_debug.txt", "a") as f:
-            #     f.write(path + "\n")
             path_examples = _get_modules_file(path, logger)
-
-            # with open("path_modules_debug.txt", "a") as f:
-            #     f.write(str(path_examples) + "\n----------\n")
-
             for lib_name, lib_metadata in path_examples.items():
-
-                walk_val = os.walk(lib_metadata["path"])
-                # with open("path_walk_debug.txt", "a") as f:
-                #     for thing in walk_val:
-                #         f.write(f"{lib_name}: " + str(thing) + "\n----\n")
-                #     f.write("\n=========================\n")
-
-                # for _example_file in os.listdir(lib_metadata["path"]):
-                #     all_the_examples[f"{lib_name}/{_example_file.replace('.py', '')}"] = os.path.join(lib_metadata["path"], f"{_example_file}")
-
                 for _dir_level in os.walk(lib_metadata["path"]):
                     for _file in _dir_level[2]:
                         _parts = _dir_level[0].split(os.path.sep)
@@ -357,13 +334,8 @@ def get_bundle_examples(bundles_list, avoid_download=False):
                         _dirs = _parts[_lib_name_index:]
                         if _dirs[-1] == "":
                             _dirs.pop(-1)
-                        with open("dirs_parts_debug.txt", "a") as f:
-                            f.write(f"{lib_name}: " + str(_dirs) + "\n----\n")
                         slug = f"{os.path.sep}".join(_dirs + [_file.replace(".py", "")])
                         all_the_examples[slug] = os.path.join(_dir_level[0], _file)
-
-                        # all_the_examples[f"{lib_name}/{_example_file.replace('.py', '')}"] = os.path.join(
-                        #     lib_metadata["path"], f"{_file}")
 
     except NotADirectoryError:
         # Bundle does not have new style examples directory

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -38,6 +38,8 @@ from circup.command_utils import (
     get_bundles_local_dict,
     save_local_bundles,
     get_bundles_dict,
+    completion_for_example,
+    get_bundle_examples,
 )
 
 
@@ -344,6 +346,29 @@ def install(ctx, modules, pyext, requirement, auto, auto_file):  # pragma: no co
         for library in to_install:
             ctx.obj["backend"].install_module(
                 ctx.obj["DEVICE_PATH"], device_modules, library, pyext, mod_names
+            )
+
+
+@main.command()
+@click.argument(
+    "examples", required=True, nargs=-1, shell_complete=completion_for_example
+)
+@click.pass_context
+def example(ctx, examples):
+    print(f"context: {ctx}")
+    for example in examples:
+        available_examples = get_bundle_examples(
+            get_bundles_list(), avoid_download=True
+        )
+        if example in available_examples:
+            click.echo(available_examples[example])
+            ctx.obj["backend"]._install_module_py(
+                {"path": available_examples[example]}, location=""
+            )
+        else:
+            click.secho(
+                f"Error: {example} was not found in any local bundle examples.",
+                fg="red",
             )
 
 


### PR DESCRIPTION
This change adds a new subcommand `circup example` which can be used to copy examples from the bundle onto the device. 

example:
```
$ circup example bme680/bme680_simpletest
$ circup example bme680/bme680_simpletest bme680/bme680_spi --overwrite
```

The name of the file is kept. If a file by this name exists on the device already a warning is printed that the file exists. User can pass `--overwrite` to replace the file even if it exists.

The command supports tab completion that tries to find matching library name / example name strings based on the partial argument entered by the user. 

`_install_module_py` and `_install_module_mpy` were refactored to become non-private (drop the leading underscore). The example command makes use of the py version of that function from outside of the Backend so it made sense to make it non-private. 

A new function was added to Backend `file_exists()` which checks if a specified file exists on the device. Currently only used by the new example command. 


I tested the new command successfully with a Feather S3 TFT via both USB and Web workflow.