### PR TITLE
Update import

### DIFF
--- a/tests/import_styles.py
+++ b/tests/import_styles.py
@@ -4,5 +4,5 @@
 # pylint: disable=all
 import adafruit_bus_device
 from adafruit_button import Button
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+from adafruit_esp32spi import adafruit_esp32spi_socketpool
 import adafruit_hid.consumer_control


### PR DESCRIPTION
With the merging of https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/198, this:
```
import adafruit_esp32spi.adafruit_esp32spi_socket as socket
```
No longer exists.

As the imports are fake, it doesn't actually cause the tests to fail, but if it ever changed in the future, it would.