### PR TITLE
fix version overriding arg

### DIFF
--- a/circup/commands.py
+++ b/circup/commands.py
@@ -112,7 +112,11 @@ def main(  # pylint: disable=too-many-locals
             device_path = device_path.replace("circuitpython.local", host)
         try:
             ctx.obj["backend"] = WebBackend(
-                host=host, password=password, logger=logger, timeout=timeout
+                host=host,
+                password=password,
+                logger=logger,
+                timeout=timeout,
+                version_override=cpy_version,
             )
         except ValueError as e:
             click.secho(e, fg="red")
@@ -123,7 +127,11 @@ def main(  # pylint: disable=too-many-locals
             sys.exit(1)
     else:
         try:
-            ctx.obj["backend"] = DiskBackend(device_path, logger)
+            ctx.obj["backend"] = DiskBackend(
+                device_path,
+                logger,
+                version_override=cpy_version,
+            )
         except ValueError as e:
             print(e)
 


### PR DESCRIPTION
resolves #218 

If `--cpy-version` CLI argument is passed by user, then pass it's value to the Backend constructor and store it in a local variable to be returned if it exists from `get_circuitpython_version()` 

I was able to successfully test this version with these commands:

```
circup --path fake_project/ --cpy-version 8.0.0 --board-id hello install adafruit_display_text
circup --path fake_project/ --cpy-version 9.0.0 --board-id hello install adafruit_display_text
```