### PR TITLE
add build for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.pypi_username }}


### PR DESCRIPTION
This is the same as here: https://github.com/adafruit/workflows-circuitpython-libs/blob/main/release-pypi/action.yml#L39 which is one of the files that the new release.yml is modeled after, I ended up changing most of the code over to a different one from circuitpython-build-tools, but in the process I mistakenly removed this install which now made the new release fail.