### PR TITLE
enable dynamic depencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circup"
-dynamic = ["version"]
+dynamic = ["version", "dependencies", "optional-dependencies"]
 description = "A tool to manage/update libraries on CircuitPython devices."
 readme = "README.rst"
 authors = [{ name = "Adafruit Industries", email = "circuitpython@adafruit.com" }]


### PR DESCRIPTION
This seems to resolve the issue of pip not installing the dependencies correctly when you do `pip install circup` 

I tested it successfully with `pip install .` and it will need re-testing with the real name once deployed.