### PR TITLE
Support web workflow on alternate port numbers

### DIFF
--- a/circup/backends.py
+++ b/circup/backends.py
@@ -277,7 +277,7 @@ class WebBackend(Backend):
     """
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, host, password, logger, timeout=10, version_override=None
+        self, host, port, password, logger, timeout=10, version_override=None
     ):
         super().__init__(logger)
         if password is None:
@@ -297,14 +297,18 @@ class WebBackend(Backend):
         self.FS_PATH = "fs/"
         self.LIB_DIR_PATH = f"{self.FS_PATH}lib/"
         self.host = host
+        self.port = port
         self.password = password
-        self.device_location = f"http://:{self.password}@{self.host}"
+        self.device_location = f"http://:{self.password}@{self.host}:{self.port}"
 
         self.session = requests.Session()
         self.session.mount(self.device_location, HTTPAdapter(max_retries=5))
         self.library_path = self.device_location + "/" + self.LIB_DIR_PATH
         self.timeout = timeout
         self.version_override = version_override
+
+    def __repr__(self):
+        return f"<WebBackend @{self.device_location}>"
 
     def install_file_http(self, source, location=None):
         """

--- a/circup/command_utils.py
+++ b/circup/command_utils.py
@@ -610,7 +610,7 @@ def libraries_from_code_py(code_py, mod_names):
     return [r for r in imports if r in mod_names]
 
 
-def get_device_path(host, password, path):
+def get_device_path(host, port, password, path):
     """
     :param host Hostname or IP address.
     :param password REST API password.
@@ -621,7 +621,7 @@ def get_device_path(host, password, path):
         device_path = path
     elif host:
         # pylint: enable=no-member
-        device_path = f"http://:{password}@" + host
+        device_path = f"http://:{password}@{host}:{port}"
     else:
         device_path = find_device()
     return device_path

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -58,6 +58,9 @@ from circup.command_utils import (
     help="Hostname or IP address of a device. Overrides automatic path detection.",
 )
 @click.option(
+    "--port", help="Port to contact. Overrides automatic path detection.", default=80
+)
+@click.option(
     "--password",
     help="Password to use for authentication when --host is used."
     " You can optionally set an environment variable CIRCUP_WEBWORKFLOW_PASSWORD"
@@ -86,7 +89,7 @@ from circup.command_utils import (
 )
 @click.pass_context
 def main(  # pylint: disable=too-many-locals
-    ctx, verbose, path, host, password, timeout, board_id, cpy_version
+    ctx, verbose, path, host, port, password, timeout, board_id, cpy_version
 ):  # pragma: no cover
     """
     A tool to manage and update libraries on a CircuitPython device.
@@ -98,7 +101,7 @@ def main(  # pylint: disable=too-many-locals
     if password is None:
         password = os.getenv("CIRCUP_WEBWORKFLOW_PASSWORD")
 
-    device_path = get_device_path(host, password, path)
+    device_path = get_device_path(host, port, password, path)
 
     using_webworkflow = "host" in ctx.params.keys() and ctx.params["host"] is not None
 
@@ -114,6 +117,7 @@ def main(  # pylint: disable=too-many-locals
         try:
             ctx.obj["backend"] = WebBackend(
                 host=host,
+                port=port,
                 password=password,
                 logger=logger,
                 timeout=timeout,


### PR DESCRIPTION
The web workflow can run on an alternate port number; I set one of my devices up this way and then noticed I couldn't use it with circup.

```
# settings.toml
CIRCUITPY_WEB_API_PORT=8080
```

With this change, I can specify `--port 8080` and successfully install libraries.