### PR TITLE
python 3.12 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: black
         exclude: "^tests/bad_python.py$"
 -   repo: https://github.com/pycqa/pylint
-    rev: v2.15.5
+    rev: v3.1.0
     hooks:
     -   id: pylint
         name: lint (examples)

--- a/.pylintrc
+++ b/.pylintrc
@@ -246,7 +246,7 @@ ignore-docstrings=yes
 ignore-imports=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=8
 
 
 [BASIC]

--- a/circup/shared.py
+++ b/circup/shared.py
@@ -10,8 +10,8 @@ import glob
 import os
 import re
 import json
+import importlib.resources
 import appdirs
-import pkg_resources
 import requests
 
 #: Version identifier for a bad MPY file format
@@ -27,9 +27,8 @@ PLATFORMS = {"py": "py", "8mpy": "8.x-mpy", "9mpy": "9.x-mpy"}
 REQUESTS_TIMEOUT = 30
 
 #: The path to the JSON file containing the metadata about the bundles.
-BUNDLE_CONFIG_FILE = pkg_resources.resource_filename(
-    "circup", "config/bundle_config.json"
-)
+BUNDLE_CONFIG_FILE = importlib.resources.files("circup") / "config/bundle_config.json"
+
 #: Overwrite the bundles list with this file (only done manually)
 BUNDLE_CONFIG_OVERWRITE = os.path.join(DATA_DIR, "bundle_config.json")
 #: The path to the JSON file containing the local list of bundles.


### PR DESCRIPTION
The two changes with this PR allow circup to be used under python 3.12 in the following contexts:


- `circup` CLI usage by the user
- pre-commit usage by developers working on circup.