### PR TITLE
Slight improvement to reading MPY files module version

### DIFF
--- a/circup/shared.py
+++ b/circup/shared.py
@@ -79,14 +79,18 @@ def _get_modules_file(path, logger):
         py_files = glob.glob(os.path.join(package_path, "**/*.py"), recursive=True)
         mpy_files = glob.glob(os.path.join(package_path, "**/*.mpy"), recursive=True)
         all_files = py_files + mpy_files
+        # put __init__ first if any, assumed to have the version number
+        all_files.sort()
         # default value
         result[name] = {"path": package_path, "mpy": bool(mpy_files)}
         # explore all the submodules to detect bad ones
         for source in [f for f in all_files if not os.path.basename(f).startswith(".")]:
             metadata = extract_metadata(source, logger)
             if "__version__" in metadata:
-                metadata["path"] = package_path
-                result[name] = metadata
+                # don't replace metadata if already found
+                if "__version__" not in result[name]:
+                    metadata["path"] = package_path
+                    result[name] = metadata
                 # break now if any of the submodules has a bad format
                 if metadata["__version__"] == BAD_FILE_FORMAT:
                     break

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,6 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
         import sphinx_rtd_theme
 
         html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
     except:
         html_theme = "default"
         html_theme_path = ["."]


### PR DESCRIPTION
There is an issue when reading the version number in `adafruit_httpserver` because [one of the files contains the string](https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer/blob/bcef270a3dcb6a4ba34a2fb4f12a972142a1390d/adafruit_httpserver/server.py#L237) `"0.0.0.0"`. Twice. (A default argument for an IP address). So the version number ends up being `0.0.0`.
```
adafruit_httpserver     0.0.0    4.5.10  Major Version
```

So as a tentative solution to situations like that, I made two changes:
- sort the files scanned by name, so that the `__init__.mpy` file is read first.
- keep the first version number found instead of updating to the last.

I believe that the version number will be the first version-like string in the file, since strings in MPY files seem to be in the same order as in the source file. So we should be good unless a module has multiple files, no init, and the top file has no `__version__` but some other version-like string. But then I'm asking: why ? And: _please don't make us decompile MPY files in circup_.