### PR TITLE
wwshell fixes

### DIFF
--- a/circup/backends.py
+++ b/circup/backends.py
@@ -329,7 +329,6 @@ class WebBackend(Backend):
         file_name = source.split(os.path.sep)
         file_name = file_name[-2] if file_name[-1] == "" else file_name[-1]
 
-        print(f"inside install_file_http location: '{location}'")
         if location is None:
             target = self.device_location + "/" + self.LIB_DIR_PATH + file_name
         else:
@@ -338,10 +337,7 @@ class WebBackend(Backend):
         auth = HTTPBasicAuth("", self.password)
 
         with open(source, "rb") as fp:
-            print(f"upload file PUT URL: {target}")
             r = self.session.put(target, fp.read(), auth=auth, timeout=self.timeout)
-            print(f"install_file_http response status: {r.status_code}")
-            print(r.content)
             if r.status_code == 409:
                 _writeable_error()
             r.raise_for_status()
@@ -584,7 +580,6 @@ class WebBackend(Backend):
         :param location_to_paste: Location on the microcontroller to paste it.
         :return:
         """
-        print(f"inside upload_file location_to_paste: '{location_to_paste}'")
         if os.path.isdir(target_file):
             create_directory_url = urljoin(
                 self.device_location,
@@ -698,7 +693,6 @@ class WebBackend(Backend):
         return True if the file exists, otherwise False.
         """
         auth = HTTPBasicAuth("", self.password)
-        print(f"URL: {self.get_file_path(filepath)}")
         resp = requests.get(
             self.get_file_path(filepath), auth=auth, timeout=self.timeout
         )
@@ -809,7 +803,6 @@ class WebBackend(Backend):
             headers={"Accept": "application/json"},
             timeout=self.timeout,
         ) as r:
-            print(r.content)
             return r.json()["files"]
 
 

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -94,7 +94,7 @@ def main(  # pylint: disable=too-many-locals
     """
     A tool to manage and update libraries on a CircuitPython device.
     """
-    # pylint: disable=too-many-arguments,too-many-branches,too-many-statements,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-branches,too-many-statements,too-many-locals, R0801
     ctx.ensure_object(dict)
     ctx.obj["TIMEOUT"] = timeout
 

--- a/circup/wwshell/commands.py
+++ b/circup/wwshell/commands.py
@@ -45,6 +45,11 @@ from circup.command_utils import (
     default="circuitpython.local",
 )
 @click.option(
+    "--port",
+    help="HTTP port that the web workflow is listening on.",
+    default=80,
+)
+@click.option(
     "--password",
     help="Password to use for authentication when --host is used."
     " You can optionally set an environment variable CIRCUP_WEBWORKFLOW_PASSWORD"
@@ -65,24 +70,23 @@ def main(  # pylint: disable=too-many-locals
     verbose,
     path,
     host,
+    port,
     password,
     timeout,
 ):  # pragma: no cover
     """
     A tool to manage files CircuitPython device over web workflow.
     """
-    # pylint: disable=too-many-arguments,too-many-branches,too-many-statements,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-branches,too-many-statements,too-many-locals, R0801
     ctx.ensure_object(dict)
     ctx.obj["TIMEOUT"] = timeout
 
     if password is None:
         password = os.getenv("CIRCUP_WEBWORKFLOW_PASSWORD")
 
-    device_path = get_device_path(host, password, path)
+    device_path = get_device_path(host, port, password, path)
 
     using_webworkflow = "host" in ctx.params.keys() and ctx.params["host"] is not None
-    print(f"host: {ctx.params['host']}")
-    print(f"using webworkflow: {using_webworkflow}")
     if using_webworkflow:
         if host == "circuitpython.local":
             click.echo("Checking versions.json on circuitpython.local to find hostname")
@@ -94,7 +98,7 @@ def main(  # pylint: disable=too-many-locals
             device_path = device_path.replace("circuitpython.local", host)
         try:
             ctx.obj["backend"] = WebBackend(
-                host=host, password=password, logger=logger, timeout=timeout
+                host=host, port=port, password=password, logger=logger, timeout=timeout
             )
         except ValueError as e:
             click.secho(e, fg="red")


### PR DESCRIPTION
After https://github.com/adafruit/circup/pull/223 was merged the actions did not pass. This PR is trying to fix the issues that caused it to fail.

The port argument was missing in some of the function calls. I must have been using a version with the default port hardcoded back when I worked on this before. 

The other pylint error was for duplicate lines between wwshell.main and circup.main. I looked for ways to refactor the initial section but didn't come to any implementation that wasn't more complex. The fact that this chunk sets a few local variables coupled with the fact that circup actually has an else block for when not using_webworkflow make it tricky to try to refactor this into a shared function. 

Also removed a handful of print statements. 