### PR TITLE
drop 8.x bundle support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       run: echo "$GITHUB_CONTEXT"
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
-      run: echo ::set-output name=repo-name::circup
+      run: echo "repo-name=circup" >> $GITHUB_OUTPUT
     - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:

--- a/circup/shared.py
+++ b/circup/shared.py
@@ -21,7 +21,7 @@ BAD_FILE_FORMAT = "Invalid"
 DATA_DIR = appdirs.user_data_dir(appname="circup", appauthor="adafruit")
 
 #: Module formats list (and the other form used in github files)
-PLATFORMS = {"py": "py", "8mpy": "8.x-mpy", "9mpy": "9.x-mpy"}
+PLATFORMS = {"py": "py", "9mpy": "9.x-mpy"}
 
 #: Timeout for requests calls like get()
 REQUESTS_TIMEOUT = 30

--- a/tests/mock_device/boot_out.txt
+++ b/tests/mock_device/boot_out.txt
@@ -1,3 +1,3 @@
-Adafruit CircuitPython 8.1.0 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
+Adafruit CircuitPython 9.0.0 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
 Board ID:this_is_a_board
 UID:AAAABBBBCCCC

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -94,10 +94,10 @@ def test_Bundle_lib_dir():
             "adafruit/adafruit-circuitpython-bundle-py/"
             "adafruit-circuitpython-bundle-py-TESTTAG/lib"
         )
-        assert bundle.lib_dir("8mpy") == (
+        assert bundle.lib_dir("9mpy") == (
             circup.shared.DATA_DIR + "/"
-            "adafruit/adafruit-circuitpython-bundle-8mpy/"
-            "adafruit-circuitpython-bundle-8.x-mpy-TESTTAG/lib"
+            "adafruit/adafruit-circuitpython-bundle-9mpy/"
+            "adafruit-circuitpython-bundle-9.x-mpy-TESTTAG/lib"
         )
 
 
@@ -378,6 +378,16 @@ def test_Module_mpy_mismatch():
         assert m2.outofdate is False
         assert m3.mpy_mismatch is True
         assert m3.outofdate is True
+    with mock.patch(
+        "circup.backends.DiskBackend.get_circuitpython_version",
+        return_value=("9.0.0", ""),
+    ):
+        assert m1.mpy_mismatch is False
+        assert m1.outofdate is False
+        assert m2.mpy_mismatch is True
+        assert m2.outofdate is True
+        assert m3.mpy_mismatch is True
+        assert m3.outofdate is True
 
 
 def test_Module_major_update_bad_versions():
@@ -419,14 +429,16 @@ def test_Module_row():
     repo = "https://github.com/adafruit/SomeLibrary.git"
     with mock.patch("circup.os.path.isfile", return_value=True), mock.patch(
         "circup.backends.DiskBackend.get_circuitpython_version",
-        return_value=("8.0.0", ""),
+        return_value=("9.0.0", ""),
     ), mock.patch("circup.logger.warning") as mock_logger:
         backend = DiskBackend("mock_device", mock_logger)
         m = Module(name, backend, repo, "1.2.3", None, False, bundle, (None, None))
         assert m.row == ("module", "1.2.3", "unknown", "Major Version")
         m = Module(name, backend, repo, "1.2.3", "1.3.4", False, bundle, (None, None))
         assert m.row == ("module", "1.2.3", "1.3.4", "Minor Version")
-        m = Module(name, backend, repo, "1.2.3", "1.2.3", True, bundle, ("9.0.0", None))
+        m = Module(
+            name, backend, repo, "1.2.3", "1.2.3", True, bundle, ("8.0.0", "9.0.0")
+        )
         assert m.row == ("module", "1.2.3", "1.2.3", "MPY Format")
 
 
@@ -806,7 +818,7 @@ def test_get_circuitpython_version():
     with mock.patch("circup.logger.warning") as mock_logger:
         backend = DiskBackend("tests/mock_device", mock_logger)
         assert backend.get_circuitpython_version() == (
-            "8.1.0",
+            "9.0.0",
             "this_is_a_board",
         )
 


### PR DESCRIPTION
As discussed in the weekly CircuitPython meeting, https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2025/2025-02-03.md#2643-in-the-weeds, we will drop building 8.x bundles. 

- This is on the checklist here: https://github.com/adafruit/circuitpython/issues/9001

@FoamyGuy I think the tests mostly don't need to change, because the testing is with mocked versions. I'll see if the tests pass!