### PR TITLE
remove circuitpython_org bundle

### DIFF
--- a/circup/config/bundle_config.json
+++ b/circup/config/bundle_config.json
@@ -1,5 +1,4 @@
 {
     "adafruit": "adafruit/Adafruit_CircuitPython_Bundle",
-    "circuitpython_community": "adafruit/CircuitPython_Community_Bundle",
-    "circuitpython_org": "circuitpython/CircuitPython_Org_Bundle"
+    "circuitpython_community": "adafruit/CircuitPython_Community_Bundle"
 }


### PR DESCRIPTION
The circuitpython org bundle isn't built for mpy 10.x so it outputs an error message when circup attempts to download it. 

This removes circuitpython org bundle. Those libraries will get migrated into the community bundle and it should require no further changes to circup to use them once that is complete. 