### PR TITLE
fix subimport finding for auto-files that are not in the root.

### DIFF
--- a/circup/command_utils.py
+++ b/circup/command_utils.py
@@ -673,14 +673,15 @@ def imports_from_code(full_content):
     return sorted(imports)
 
 
-def get_all_imports(
-    backend, auto_file_content, mod_names, current_module, visited=None
+def get_all_imports(  # pylint: disable=too-many-arguments,too-many-locals, too-many-branches
+    backend, auto_file_content, auto_file_path, mod_names, current_module, visited=None
 ):
     """
     Recursively retrieve imports from files on the backend
 
     :param Backend backend: The current backend object
     :param str auto_file_content: Content of the python file to analyse
+    :param str auto_file_path: Path to the python file to analyse
     :param list mod_names: Lits of supported bundle mod names
     :param str current_module: Name of the call context module if recursive call
     :param set visited: Modules previously visited
@@ -714,18 +715,35 @@ def get_all_imports(
                 install_module = install
             # possible files for the module: .py or __init__.py (if directory)
             file_name = os.path.join(*install_module.split(".")) + ".py"
-            exists = backend.file_exists(file_name)
+            try:
+                file_location = os.path.join(
+                    *auto_file_path.replace(str(backend.device_location), "").split(
+                        "/"
+                    )[:-1]
+                )
+                full_location = os.path.join(file_location, file_name)
+            except TypeError:
+                # file is in root of CIRCUITPY
+                full_location = file_name
+
+            exists = backend.file_exists(full_location)
             if not exists:
                 file_name = os.path.join(*install_module.split("."), "__init__.py")
-                exists = backend.file_exists(file_name)
+                full_location = os.path.join(file_location, file_name)
+                exists = backend.file_exists(full_location)
                 if not exists:
                     continue
                 install_module += ".__init__"
             # get the content and parse it recursively
-            auto_file_content = backend.get_file_content(file_name)
+            auto_file_content = backend.get_file_content(full_location)
             if auto_file_content:
                 sub_imports = get_all_imports(
-                    backend, auto_file_content, mod_names, install_module, visited
+                    backend,
+                    auto_file_content,
+                    auto_file_path,
+                    mod_names,
+                    install_module,
+                    visited,
                 )
                 requested_installs.extend(sub_imports)
 
@@ -775,7 +793,9 @@ def libraries_from_auto_file(backend, auto_file, mod_names):
     # from file name to module name (in case it's in a subpackage)
     click.secho(f"Finding imports from: {auto_file}", fg="green")
     current_module = auto_file.rstrip(".py").replace(os.path.sep, ".")
-    return get_all_imports(backend, auto_file_content, mod_names, current_module)
+    return get_all_imports(
+        backend, auto_file_content, auto_file, mod_names, current_module
+    )
 
 
 def get_device_path(host, port, password, path):

--- a/circup/command_utils.py
+++ b/circup/command_utils.py
@@ -721,7 +721,9 @@ def get_all_imports(  # pylint: disable=too-many-arguments,too-many-locals, too-
                         "/"
                     )[:-1]
                 )
+
                 full_location = os.path.join(file_location, file_name)
+
             except TypeError:
                 # file is in root of CIRCUITPY
                 full_location = file_name
@@ -729,7 +731,7 @@ def get_all_imports(  # pylint: disable=too-many-arguments,too-many-locals, too-
             exists = backend.file_exists(full_location)
             if not exists:
                 file_name = os.path.join(*install_module.split("."), "__init__.py")
-                full_location = os.path.join(file_location, file_name)
+                full_location = file_name
                 exists = backend.file_exists(full_location)
                 if not exists:
                     continue

--- a/tests/mock_device/apps/test_app/import_styles.py
+++ b/tests/mock_device/apps/test_app/import_styles.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2021 Jeff Epler for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+# pylint: disable=all
+import os, sys
+import adafruit_bus_device
+from adafruit_button import Button
+from adafruit_esp32spi import adafruit_esp32spi_socketpool
+from adafruit_display_text import wrap_text_to_pixels, wrap_text_to_lines
+import adafruit_hid.consumer_control
+import import_styles_sub

--- a/tests/mock_device/apps/test_app/import_styles_sub.py
+++ b/tests/mock_device/apps/test_app/import_styles_sub.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 Neradoc
+#
+# SPDX-License-Identifier: MIT
+# pylint: disable=all
+import adafruit_ntp

--- a/tests/mock_device/boot_out.txt
+++ b/tests/mock_device/boot_out.txt
@@ -1,3 +1,3 @@
-Adafruit CircuitPython 9.0.0 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
+Adafruit CircuitPython 10.0.0-alpha.6 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
 Board ID:this_is_a_board
 UID:AAAABBBBCCCC

--- a/tests/mock_device/boot_out.txt
+++ b/tests/mock_device/boot_out.txt
@@ -1,3 +1,3 @@
-Adafruit CircuitPython 10.0.0-alpha.6 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
+Adafruit CircuitPython 9.0.0 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
 Board ID:this_is_a_board
 UID:AAAABBBBCCCC

--- a/tests/mock_device/import_styles.py
+++ b/tests/mock_device/import_styles.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2021 Jeff Epler for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+# pylint: disable=all
+import os, sys
+import adafruit_bus_device
+from adafruit_button import Button
+from adafruit_esp32spi import adafruit_esp32spi_socketpool
+from adafruit_display_text import wrap_text_to_pixels, wrap_text_to_lines
+import adafruit_hid.consumer_control
+import import_styles_sub

--- a/tests/mock_device_2/boot_out.txt
+++ b/tests/mock_device_2/boot_out.txt
@@ -1,3 +1,3 @@
-Adafruit CircuitPython 8.1.0 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
+Adafruit CircuitPython 9.0.0 on 2019-08-02; Adafruit CircuitPlayground Express with samd21g18
 Board ID:this_is_a_board
 UID:AAAABBBBCCCC

--- a/tests/mock_device_2/import_styles_sub.py
+++ b/tests/mock_device_2/import_styles_sub.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 Neradoc
+#
+# SPDX-License-Identifier: MIT
+# pylint: disable=all
+import adafruit_ntp

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -1186,7 +1186,11 @@ def test_get_all_imports():
             test_data = fp.read()
 
         result = get_all_imports(
-            backend, test_data, test_file, mod_names, current_module=""
+            backend,
+            test_data,
+            os.path.join(backend.device_location, "import_styles.py"),
+            mod_names,
+            current_module="",
         )
 
     assert result == [
@@ -1215,7 +1219,7 @@ def test_libraries_from_auto_file_local():
         "adafruit_ntp",
     ]
 
-    auto_file = "./tests/import_styles.py"
+    auto_file = "apps/test_app/import_styles.py"
 
     with mock.patch("circup.logger.info") as mock_logger, mock.patch(
         "circup.os.path.isfile", return_value=True
@@ -1267,6 +1271,7 @@ def test_libraries_from_auto_file_board():
         result = libraries_from_auto_file(backend, auto_file, mod_names)
 
     assert result == [
+        "adafruit_ntp",
         "adafruit_spd1608",
         "adafruit_spd1656",
         "adafruit_ssd1675",

--- a/tests/test_circup.py
+++ b/tests/test_circup.py
@@ -1185,7 +1185,9 @@ def test_get_all_imports():
         with open(test_file, "r", encoding="utf8") as fp:
             test_data = fp.read()
 
-        result = get_all_imports(backend, test_data, mod_names, current_module="")
+        result = get_all_imports(
+            backend, test_data, test_file, mod_names, current_module=""
+        )
 
     assert result == [
         "adafruit_bus_device",


### PR DESCRIPTION
resolves #252.

In order for `get_all_imports()` to be able to recursively find subimports it must know where the original file is located instead of just the content of that file. Otherwise it won't be able to find files that are stored alongside `code.py` in directores that are outside of the root such as the ones used by Fruit Jam OS like: `apps/something/` 

This change adds the filepath as an argument and uses it to locate the imported files. Theoretically we could remove the file content arg and read the file inside of the function if we wanted one fewer arguments. I left it as is for now though and do not have a strong preference one way or the other in this case. 