### PR TITLE
Add lazy metadata for module metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,9 @@ venv.bak/
 # VSCode
 .vscode/
 
+# Zed
+.zed/
+
 .DS_STORE
 
 # emacs

--- a/circup/lazy_metadata.py
+++ b/circup/lazy_metadata.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 George Waters
+#
+# SPDX-License-Identifier: MIT
+"""
+Class that acts similar to a dictionary, but defers the loading of expensive
+data until that data is accessed.
+"""
+from typing import Any, Callable
+
+
+class LazyMetadata:
+    """
+    Dictionary like class that stores module metadata. Expensive to load
+    metadata won't be loaded until it is accessed.
+    """
+
+    def __init__(
+        self,
+        deferred_load: Callable[[], dict[str, Any]],
+        initial_data: dict[str, Any] | None = None,
+    ):
+        """
+        Initialize a LazyMetadata object by providing a callable and initial
+        data.
+
+        :param deferred_load: A callable that returns a dictionary of metadata.
+        This is not invoked until a key is accessed that is not available in
+        :py:attr:`initial_data`.
+        :param initial_data: A dictionary containing the initial metadata.
+        """
+        self._deferred_load = deferred_load
+        self.initial_data = initial_data.copy() if initial_data is not None else {}
+        self._deferred_data: dict[str, Any] | None = None
+
+    @property
+    def deferred_data(self) -> dict[str, Any]:
+        """
+        Lazy load the metadata from :py:attr:`_deferred_load`.
+
+        :return: The "expensive" metadata that was loaded from
+        :py:attr:`_deferred_load`.
+        """
+        if self._deferred_data is None:
+            self._deferred_data = self._deferred_load()
+        return self._deferred_data
+
+    def __getitem__(self, key: str) -> Any:
+        """
+        Get items via keyed index lookup, like a dictionary.
+
+        Keys are first looked for in :py:attr:`initial_data`, if the key isn't
+        found it is then looked for in :py:attr:`deferred_data`.
+
+        :param key: Key to a metadata value.
+        :return: Metadata value for the given key.
+        :raises KeyError: If the key cannot be found.
+        """
+        if key in self.initial_data:  # pylint: disable=no-else-return
+            return self.initial_data[key]
+        elif key in self.deferred_data:
+            return self.deferred_data[key]
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, item: Any) -> None:
+        """
+        Sets the item under the given key.
+
+        The item is set in the :py:attr:`initial_data` dictionary.
+
+        :param key: Key to a metadata value.
+        :param item: Metadata value
+        """
+        self.initial_data[key] = item
+
+    def __contains__(self, key: str):
+        """
+        Whether or not a key is present.
+
+        This checks both :py:attr:`initial_data` and :py:attr:`deferred_data`
+        for the key. *Note* this will cause :py:attr:`deferred_data` to load
+        the deferred data if it is not already.
+        """
+        return key in self.initial_data or key in self.deferred_data
+
+    def get(self, key: str, default: Any = None):
+        """
+        Get items via keyed index lookup, like a dictionary.
+
+        Also like a dictionary, this method doesn't error if the key is not
+        found. :param default: is returned if the key is not found.
+
+        :param key: Key to a metadata value.
+        :param default: Default value to return when the key doesn't exist.
+        :return: Metadata value for the given key.
+        """
+        if key in self:
+            return self[key]
+        return default
+
+    def __repr__(self) -> str:
+        """
+        Helps with log files.
+
+        :return: A repr of a dictionary containing the metadata's values.
+        """
+        return repr(
+            {
+                "initial_data": self.initial_data,
+                "deferred_data": self._deferred_data
+                if self._deferred_data is not None
+                else "<Not Loaded>",
+            }
+        )

--- a/circup/shared.py
+++ b/circup/shared.py
@@ -14,6 +14,8 @@ import importlib.resources
 import appdirs
 import requests
 
+from circup.lazy_metadata import LazyMetadata
+
 #: Version identifier for a bad MPY file format
 BAD_FILE_FORMAT = "Invalid"
 
@@ -51,7 +53,7 @@ NOT_MCU_LIBRARIES = [
 BOARDLESS_COMMANDS = ["show", "bundle-add", "bundle-remove", "bundle-show"]
 
 
-def _get_modules_file(path, logger):
+def _get_modules_file(path, logger):  # pylint: disable=too-many-locals
     """
     Get a dictionary containing metadata about all the Python modules found in
     the referenced file system path.
@@ -71,8 +73,10 @@ def _get_modules_file(path, logger):
     ]
     single_file_mods = single_file_py_mods + single_file_mpy_mods
     for sfm in [f for f in single_file_mods if not os.path.basename(f).startswith(".")]:
-        metadata = extract_metadata(sfm, logger)
-        metadata["path"] = sfm
+        default_metadata = {"path": sfm, "mpy": sfm.endswith(".mpy")}
+        metadata = LazyMetadata(
+            lambda sfm=sfm: extract_metadata(sfm, logger), default_metadata
+        )
         result[os.path.basename(sfm).replace(".py", "").replace(".mpy", "")] = metadata
     for package_path in package_dir_mods:
         name = os.path.basename(os.path.dirname(package_path))
@@ -81,19 +85,27 @@ def _get_modules_file(path, logger):
         all_files = py_files + mpy_files
         # put __init__ first if any, assumed to have the version number
         all_files.sort()
+
+        def get_metadata(all_files=all_files):  # capture all_files
+            selected_metadata = {}
+            # explore all the submodules to detect bad ones
+            for source in [
+                f for f in all_files if not os.path.basename(f).startswith(".")
+            ]:
+                metadata = extract_metadata(source, logger)
+                if "__version__" in metadata:
+                    # don't replace metadata if already found
+                    if "__version__" not in selected_metadata:
+                        selected_metadata = metadata
+                    # break now if any of the submodules has a bad format
+                    if metadata["__version__"] == BAD_FILE_FORMAT:
+                        break
+            return selected_metadata
+
         # default value
-        result[name] = {"path": package_path, "mpy": bool(mpy_files)}
-        # explore all the submodules to detect bad ones
-        for source in [f for f in all_files if not os.path.basename(f).startswith(".")]:
-            metadata = extract_metadata(source, logger)
-            if "__version__" in metadata:
-                # don't replace metadata if already found
-                if "__version__" not in result[name]:
-                    metadata["path"] = package_path
-                    result[name] = metadata
-                # break now if any of the submodules has a bad format
-                if metadata["__version__"] == BAD_FILE_FORMAT:
-                    break
+        default_metadata = {"path": package_path, "mpy": bool(mpy_files)}
+        metadata = LazyMetadata(get_metadata, default_metadata)
+        result[name] = metadata
     return result
 
 


### PR DESCRIPTION
This defers the loading/computing of some of the metadata information for modules until it is accessed. This greatly improves performance because most of the modules are not actually used and therefore their metadata is also not used or needed. The time required to open and process all the module files can be avoided.

I came across this wile working on the other PR I opened. I thought maybe it had to do with how the bundle data json file was being used, but after profiling it was clear it was coming from opening all the module files.

I ran a simple test to get an idea of the change. The setup was running `time circup --path ./test-device install -r requirements.txt` where this is what I had in `requirements.txt`:

```
adafruit_pixelbuf==2.0.10
ifttt==0.0.1
neopixel==6.3.18
adafruit_motor==3.4.18
```

I ran it multiple times and got pretty consistent times before and after this change.
Before: `1.950 sec total`
After: `1.070 sec total`