### PR TITLE
Add an '--offline' flag to avoid network requests

### DIFF
--- a/circup/bundle.py
+++ b/circup/bundle.py
@@ -25,6 +25,9 @@ class Bundle:
     All the links and file names for a bundle
     """
 
+    #: Avoid requests to the internet
+    offline = False
+
     def __init__(self, repo):
         """
         Initialise a Bundle created from its github info.
@@ -132,9 +135,12 @@ class Bundle:
         :return: The most recent tag value for the project.
         """
         if self._latest is None:
-            self._latest = get_latest_release_from_url(
-                self.url + "/releases/latest", logger
-            )
+            if self.offline:
+                self._latest = self._available[-1] if len(self._available) > 0 else None
+            else:
+                self._latest = get_latest_release_from_url(
+                    self.url + "/releases/latest", logger
+                )
         return self._latest
 
     @property

--- a/circup/command_utils.py
+++ b/circup/command_utils.py
@@ -145,6 +145,10 @@ def ensure_bundle_tag(bundle, tag):
 
     :return: If the bundle is available.
     """
+    if tag is None:
+        logger.warning("Bundle version requested is 'None'.")
+        return False
+
     do_update = False
     if tag in bundle.available_tags:
         for platform in PLATFORMS:
@@ -155,6 +159,12 @@ def ensure_bundle_tag(bundle, tag):
         do_update = True
 
     if do_update:
+        if Bundle.offline:
+            logger.info(
+                "Bundle version not available but skipping update in offline mode."
+            )
+            return False
+
         logger.info("New version available (%s).", tag)
         try:
             get_bundle(bundle, tag)


### PR DESCRIPTION
If you want to use circup but don't have an internet connection, you currently cannot. This commit skips all network requests and will try to perform the commands with whatever data is already downloaded.