### PR TITLE
Fix for specifying cpy-version when installing

### DIFF
--- a/circup/commands.py
+++ b/circup/commands.py
@@ -141,6 +141,10 @@ def main(  # pylint: disable=too-many-locals
 
     using_webworkflow = "host" in ctx.params.keys() and ctx.params["host"] is not None
 
+    version_override = None
+    if board_id or cpy_version:
+        version_override = (cpy_version, board_id)
+
     if using_webworkflow:
         if host == "circuitpython.local":
             click.echo("Checking versions.json on circuitpython.local to find hostname")
@@ -157,7 +161,7 @@ def main(  # pylint: disable=too-many-locals
                 password=password,
                 logger=logger,
                 timeout=timeout,
-                version_override=cpy_version,
+                version_override=version_override,
             )
         except ValueError as e:
             click.secho(e, fg="red")
@@ -171,7 +175,7 @@ def main(  # pylint: disable=too-many-locals
             ctx.obj["backend"] = DiskBackend(
                 device_path,
                 logger,
-                version_override=cpy_version,
+                version_override=version_override,
             )
         except ValueError as e:
             print(e)


### PR DESCRIPTION
# Scope
Fixing an exception issue when using circup, and specifying --cpy-version.  This makes changes to the main() and version_override values passed to the backends.  Previously this value was set to a string, but usage of get_circuitpython_version() returned a tuple.

# Behavior
Previously, calling `circup --path . --cpy-version '10.0.3' --board-id adafruit_qtpy_esp32s2 install adafruit-circuitpython-asyncio` caused an exception:
```
  File "...\Lib\site-packages\circup\bundle.py", line 61, in lib_dir
    self.basename.format(platform=PLATFORMS[platform], tag=tag),
                                  ~~~~~~~~~^^^^^^^^^^
KeyError: '1mpy'
```

This was due to this line:
```
# DiskBackEnd.install_module_mpy()
...
major_version = self.get_circuitpython_version()[0].split(".")[0]
```
Requiring the return value to be a tuple, the first entry to be a semver.  This fix resolves this.