### PR TITLE
Made error message more clear when device is out of storage space

### DIFF
--- a/circup/backends.py
+++ b/circup/backends.py
@@ -184,12 +184,12 @@ class Backend:
 
             if self.get_free_space() < new_module_size:
                 self.logger.error(
-                    f"Aborted installing module {name} - "
-                    f"not enough free space ({new_module_size} < {self.get_free_space()})"
+                    f"Aborted installing module {name} - it needs {new_module_size} bytes "
+                    f"but only {self.get_free_space()} bytes of storage is available"
                 )
                 click.secho(
-                    f"Aborted installing module {name} - "
-                    f"not enough free space ({new_module_size} < {self.get_free_space()})",
+                    f"Aborted installing module {name} - it needs {new_module_size} bytes "
+                    f"but only {self.get_free_space()} bytes of storage is available",
                     fg="red",
                 )
                 return


### PR DESCRIPTION
This is a simple change to make the error message more clear when running of out space while attempting to install a module. 

### Before:

Aborted installing module adafruit_led_animation - not enough free space (103160 < 41984)

### After:

Aborted installing module adafruit_led_animation - it needs 103160 bytes but only 41984 bytes of storage is available
