### PR TITLE
bugfix: Upgrade reuse-tool to alleviate pre-commit failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         types: [python]
         exclude: "^(docs/|examples/|setup.py$|tests/bad_python.py$)"
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v0.14.0
+    rev: v3.0.2
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
I appears that this project is using a older version of reuse tool. The error `ModuleNotFoundError: No module named 'pkg_resources'` happens because it was removed from the setuptools package from 70 on. Upgrading to a more current version of the reuse tool resolves this issue.