### PR TITLE
Offline mode

### DIFF
--- a/circup/bundle.py
+++ b/circup/bundle.py
@@ -99,18 +99,24 @@ class Bundle:  # pylint: disable=too-many-instance-attributes
         :param str library_name: The name of the library.
         :return: The path to the requirements.txt file.
         """
-        platform = "py"
         tag = self.current_tag
-        found_file = os.path.join(
-            self.dir.format(platform=platform),
-            self.basename.format(platform=PLATFORMS[platform], tag=tag),
-            "requirements",
-            library_name,
-            "requirements.txt" if not toml_file else "pyproject.toml",
-        )
-        if os.path.isfile(found_file):
-            with open(found_file, encoding="utf-8") as read_this:
-                return read_this.read()
+        filename = "requirements.txt" if not toml_file else "pyproject.toml"
+        # Prefer the py bundle (human-readable source), but fall back to any
+        # platform that has the requirements directory extracted locally.
+        platforms_to_try = ["py"] + [
+            p for p in PLATFORMS if p != "py"
+        ]
+        for platform in platforms_to_try:
+            found_file = os.path.join(
+                self.dir.format(platform=platform),
+                self.basename.format(platform=PLATFORMS[platform], tag=tag),
+                "requirements",
+                library_name,
+                filename,
+            )
+            if os.path.isfile(found_file):
+                with open(found_file, encoding="utf-8") as read_this:
+                    return read_this.read()
         return None
 
     @property

--- a/circup/command_utils.py
+++ b/circup/command_utils.py
@@ -227,8 +227,16 @@ def ensure_latest_bundle(bundle):
         click.echo(f"Using latest bundle for {bundle.key} ({tag}).")
     else:
         if bundle.current_tag is None:
-            # See issue #20 for reason for this
-            click.secho("Please try again in a moment.", fg="red")
+            if Bundle.offline:
+                click.secho(
+                    f"Bundle '{bundle.key}' is not available locally. "
+                    "Use 'circup bundle-extract <zip>' to add a local bundle, "
+                    "or remove '--offline' to download it from GitHub.",
+                    fg="red",
+                )
+            else:
+                # See issue #20 for reason for this
+                click.secho("Please try again in a moment.", fg="red")
             sys.exit(1)
         else:
             # See PR #184 for reason for this
@@ -343,7 +351,7 @@ def find_device():
     return device_dir
 
 
-def find_modules(backend, bundles_list):
+def find_modules(backend, bundles_list, avoid_download=False):
     """
     Extracts metadata from the connected device and available bundles and
     returns this as a list of Module instances representing the modules on the
@@ -351,13 +359,15 @@ def find_modules(backend, bundles_list):
 
     :param Backend backend: Backend with the device connection.
     :param List[Bundle] bundles_list: List of supported bundles as Bundle objects.
+    :param bool avoid_download: if True, use locally cached bundle without checking
+        for updates. Defaults to False.
     :return: A list of Module instances describing the current state of the
              modules on the connected device.
     """
     # pylint: disable=broad-except,too-many-locals
     try:
         device_modules = backend.get_device_versions()
-        bundle_modules = get_bundle_versions(bundles_list)
+        bundle_modules = get_bundle_versions(bundles_list, avoid_download=avoid_download)
         result = []
         for key, device_metadata in device_modules.items():
 
@@ -449,7 +459,10 @@ def get_bundle_examples(bundles_list, avoid_download=False):
 
     try:
         for bundle in bundles_list:
-            if not avoid_download or not os.path.isdir(bundle.lib_dir(source=True)):
+            if not avoid_download or (
+                not Bundle.offline
+                and not os.path.isdir(bundle.lib_dir(source=True))
+            ):
                 ensure_bundle(bundle)
             path = bundle.examples_dir(source=True)
             meta_saved = os.path.join(path, "../bundle_examples.json")
@@ -503,6 +516,9 @@ def get_bundle_versions(bundles_list, avoid_download=False):
         ):
             ensure_bundle(bundle)
         path = bundle.lib_dir(source=True)
+        if avoid_download and not os.path.isdir(path):
+            # py bundle not extracted locally; fall back to compiled platform bundle
+            path = bundle.lib_dir(source=False)
         path_modules = _get_modules_file(path, logger)
         for name, module in path_modules.items():
             module["bundle"] = bundle

--- a/circup/command_utils.py
+++ b/circup/command_utils.py
@@ -497,7 +497,10 @@ def get_bundle_versions(bundles_list, avoid_download=False):
     """
     all_the_modules = dict()
     for bundle in bundles_list:
-        if not avoid_download or not os.path.isdir(bundle.lib_dir(source=True)):
+        if not avoid_download or (
+            not Bundle.offline
+            and not os.path.isdir(bundle.lib_dir(source=True))
+        ):
             ensure_bundle(bundle)
         path = bundle.lib_dir(source=True)
         path_modules = _get_modules_file(path, logger)

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -750,7 +750,9 @@ def bundle_show(ctx, modules):
     """
     local_bundles = get_bundles_local_dict().values()
     bundles = get_bundles_list(ctx.obj["BUNDLE_TAGS"])
-    available_modules = get_bundle_versions(bundles)
+    available_modules = (
+        get_bundle_versions(bundles, avoid_download=True) if modules else {}
+    )
 
     for bundle in bundles:
         if bundle.key in local_bundles:
@@ -760,7 +762,7 @@ def bundle_show(ctx, modules):
         click.echo("    " + bundle.url)
         click.echo(
             "    version = "
-            + bundle.current_tag
+            + (bundle.current_tag or "(not downloaded)")
             + (" (pinned)" if bundle.pinned_tag is not None else "")
         )
         click.echo("    available versions:")

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -970,6 +970,15 @@ def bundle_extract(zip_path):  # pragma: no cover
                     click.secho(
                         f"OK: {bundle.key} ({tag}) [{platform_string}]", fg="green"
                     )
+                    if platform_key != "py":
+                        py_lib_dir = bundle.dir.format(platform="py")
+                        if not os.path.isdir(py_lib_dir):
+                            click.secho(
+                                "NOTE: The 'py' (source) bundle is not extracted. "
+                                "Dependency resolution requires it — also run "
+                                f"'circup bundle-extract <{bundle.basename.format(platform=PLATFORMS['py'], tag=tag)}.zip>'.",
+                                fg="yellow",
+                            )
                     matched = True
                     break
             if matched:

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -16,6 +16,7 @@ import time
 import sys
 import re
 import logging
+import zipfile
 import update_checker
 from semver import VersionInfo
 import click
@@ -26,6 +27,7 @@ from circup.backends import WebBackend, DiskBackend
 from circup.logging import logger, log_formatter, LOGFILE
 from circup.shared import (
     BOARDLESS_COMMANDS,
+    PLATFORMS,
     SUPPORTED_PLATFORMS,
     get_latest_release_from_url,
 )
@@ -48,6 +50,8 @@ from circup.command_utils import (
     completion_for_example,
     get_bundle_examples,
     is_virtual_env_active,
+    tags_data_load,
+    tags_data_save_tags,
 )
 
 
@@ -883,6 +887,76 @@ def bundle_remove(bundle, reset):
                 )
     if modified:
         save_local_bundles(bundles_local_dict)
+
+
+@main.command("bundle-extract")
+@click.argument(
+    "zip_path",
+    nargs=-1,
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+)
+def bundle_extract(zip_path):  # pragma: no cover
+    """
+    Extract one or more locally downloaded bundle zip files into circup's data
+    directory, registering them for use without downloading from GitHub.
+
+    ZIP_PATH is the path to one or more bundle zip files, e.g.
+    adafruit-circuitpython-bundle-9.x-mpy-20250115.zip
+    """
+    logger.info("Bundle Extract")
+
+    # Reverse-map platform string -> platform key (e.g. "9.x-mpy" -> "9mpy")
+    platform_by_string = {v: k for k, v in PLATFORMS.items()}
+
+    # Load all known bundles with their existing available tags
+    tags_data = tags_data_load()
+    bundles_list = []
+    for repo in get_bundles_dict().values():
+        bundle = Bundle(repo)
+        bundle.available_tags = tags_data.get(bundle.key, [])
+        bundles_list.append(bundle)
+
+    for zpath in zip_path:
+        filename = os.path.basename(zpath)
+        matched = False
+
+        for bundle in bundles_list:
+            for platform_string, platform_key in platform_by_string.items():
+                # Build the expected filename prefix, e.g.
+                # "adafruit-circuitpython-bundle-9.x-mpy-"
+                zip_prefix = bundle.urlzip.format(
+                    platform=platform_string, tag=""
+                )[: -len(".zip")]
+                if filename.startswith(zip_prefix) and filename.endswith(".zip"):
+                    tag = filename[len(zip_prefix) : -len(".zip")]
+                    if not tag:
+                        continue
+
+                    dest_dir = bundle.dir.format(platform=platform_key)
+                    os.makedirs(dest_dir, exist_ok=True)
+                    click.echo(
+                        f"Extracting '{filename}' ({platform_string}, tag={tag}) "
+                        f"into {dest_dir} ..."
+                    )
+                    with zipfile.ZipFile(zpath, "r") as zfile:
+                        zfile.extractall(dest_dir)
+                    bundle.add_tag(tag)
+                    tags_data_save_tags(bundle.key, list(bundle.available_tags))
+                    click.secho(
+                        f"OK: {bundle.key} ({tag}) [{platform_string}]", fg="green"
+                    )
+                    matched = True
+                    break
+            if matched:
+                break
+
+        if not matched:
+            click.secho(
+                f"Could not match '{filename}' to any known bundle. "
+                "Make sure the bundle is added first with 'circup bundle-add'.",
+                fg="red",
+            )
 
 
 @main.command()

--- a/circup/commands.py
+++ b/circup/commands.py
@@ -55,7 +55,19 @@ from circup.command_utils import (
 )
 
 
-@click.group()
+class _OfflineAwareGroup(click.Group):
+    """Move --offline/--no-offline before the subcommand so Click treats it
+    as a group-level option regardless of where the user typed it."""
+
+    def parse_args(self, ctx, args):
+        for flag in ("--offline", "--no-offline"):
+            if flag in args:
+                args.remove(flag)
+                args.insert(0, flag)
+        return super().parse_args(ctx, args)
+
+
+@click.group(cls=_OfflineAwareGroup)
 @click.option(
     "--verbose", is_flag=True, help="Comprehensive logging is sent to stdout."
 )
@@ -291,7 +303,11 @@ def freeze(ctx, requirement):  # pragma: no cover
     device. Option -r saves output to requirements.txt file
     """
     logger.info("Freeze")
-    modules = find_modules(ctx.obj["backend"], get_bundles_list(ctx.obj["BUNDLE_TAGS"]))
+    modules = find_modules(
+        ctx.obj["backend"],
+        get_bundles_list(ctx.obj["BUNDLE_TAGS"]),
+        avoid_download=Bundle.offline,
+    )
     if modules:
         output = []
         for module in modules:
@@ -344,6 +360,7 @@ def list_cli(ctx):  # pragma: no cover
             get_bundles_list(
                 ctx.obj["BUNDLE_TAGS"], ctx.obj["DEVICE_PLATFORM_VERSION"]
             ),
+            avoid_download=Bundle.offline,
         )
         if m.outofdate
     ]
@@ -422,7 +439,8 @@ def install(
     # TODO: Ensure there's enough space on the device
     platform_version = ctx.obj["DEVICE_PLATFORM_VERSION"] if not pyext else None
     available_modules = get_bundle_versions(
-        get_bundles_list(ctx.obj["BUNDLE_TAGS"], platform_version)
+        get_bundles_list(ctx.obj["BUNDLE_TAGS"], platform_version),
+        avoid_download=Bundle.offline,
     )
     mod_names = {}
     for module, metadata in available_modules.items():
@@ -582,7 +600,9 @@ def show(ctx, match):  # pragma: no cover
 
     If MATCH is specified only matching modules will be listed.
     """
-    available_modules = get_bundle_versions(get_bundles_list(ctx.obj["BUNDLE_TAGS"]))
+    available_modules = get_bundle_versions(
+        get_bundles_list(ctx.obj["BUNDLE_TAGS"]), avoid_download=True
+    )
     module_names = sorted([m.replace(".py", "") for m in available_modules])
     if match is not None:
         match = match.lower()
@@ -646,7 +666,9 @@ def update(ctx, update_all):  # pragma: no cover
     bundles_list = get_bundles_list(
         ctx.obj["BUNDLE_TAGS"], ctx.obj["DEVICE_PLATFORM_VERSION"]
     )
-    installed_modules = find_modules(ctx.obj["backend"], bundles_list)
+    installed_modules = find_modules(
+        ctx.obj["backend"], bundles_list, avoid_download=Bundle.offline
+    )
     modules_to_update = [m for m in installed_modules if m.outofdate]
 
     if not modules_to_update:
@@ -975,7 +997,9 @@ def bundle_freeze(ctx):  # pragma: no cover
         click.echo("No modules found on the device.")
         return
 
-    available_modules = get_bundle_versions(get_bundles_list(ctx.obj["BUNDLE_TAGS"]))
+    available_modules = get_bundle_versions(
+        get_bundles_list(ctx.obj["BUNDLE_TAGS"]), avoid_download=True
+    )
     bundles_used = {}
     for name in device_modules:
         module = available_modules.get(name)

--- a/circup/shared.py
+++ b/circup/shared.py
@@ -52,7 +52,7 @@ NOT_MCU_LIBRARIES = [
 ]
 
 #: Commands that do not require an attached board
-BOARDLESS_COMMANDS = ["show", "bundle-add", "bundle-remove", "bundle-show"]
+BOARDLESS_COMMANDS = ["show", "bundle-add", "bundle-remove", "bundle-show", "bundle-extract"]
 
 
 def _get_modules_file(path, logger):  # pylint: disable=too-many-locals


### PR DESCRIPTION
- Adds support for existing "--offline" option
- Adds `bundle-extract` command to import a downloaded bundle (i.e. from circuitpython.org). Unfortunately, this breaks the dependency management. I am interested in ideas for how to fix this.

## Offline Mode (`--offline`) Behaviour by Command

| Command | `--offline` behaviour |
|---|---|
| `install` | Reads module list and resolves dependencies from local bundle only; no GitHub/PyPI calls. `--stubs` is silently skipped. Fails with "not a known library" if no bundle is extracted locally. |
| `update` | Compares device versions against local bundle; no GitHub calls. Post-update dependency check also uses local bundle. Will report everything as up-to-date if the local bundle tag is older than what's on the device. |
| `list` | Compares device versions against local bundle; no GitHub calls. Same caveat on stale local bundle. |
| `freeze` | Lists modules found on device with their installed versions; uses local bundle for version metadata. No network calls. |
| `show` | Always reads from local bundle only (no download regardless of `--offline`). No change in behaviour. |
| `uninstall` | No bundle or network access at all. No change in behaviour. |
| `example` | Always reads from local bundle only (`avoid_download=True` unconditionally). No change in behaviour. |
| `bundle-show` | Always reads from local bundle only. No change in behaviour. |
| `bundle-add` | **Blocked** — exits immediately with an error message when `--offline` is set. |
| `bundle-remove` | No network calls. No change in behaviour. |
| `bundle-extract` | No network calls (local zip only). No change in behaviour. |
| `bundle-freeze` | Reads from local bundle only (`avoid_download=True` unconditionally). No change in behaviour. |

> **Notes applicable to all commands when `--offline` is set:**
> - The circup self-update check is skipped.
> - The CircuitPython firmware latest-version check is skipped.
> - If no bundle has been extracted locally, commands that need module metadata will fail or return empty results. Use `circup bundle-extract <zip>` first.
> - Dependency resolution requires the `py` bundle to be extracted (the `mpy` zips do not include a `requirements/` directory).