### PR TITLE
add move_file to WebBackend and mv to wwshel CLI

### DIFF
--- a/circup/backends.py
+++ b/circup/backends.py
@@ -812,6 +812,25 @@ class WebBackend(Backend):
         ) as r:
             return r.json()["files"]
 
+    def move_file(self, target_file, destination):
+        """
+        Rename or move a file or directory to the specified destination.
+        """
+        if not target_file:
+            raise ValueError("Target file cannot be empty.")
+        if not destination:
+            raise ValueError("Destination path cannot be empty.")
+        auth = HTTPBasicAuth("", self.password)
+        with self.session.request(
+            "MOVE",
+            urljoin(self.device_location, f"fs/{target_file}"),
+            auth=auth,
+            headers={"X-Destination": f"/fs/{destination}"},
+            timeout=self.timeout,
+        ) as r:
+            click.echo("move complete")
+            r.raise_for_status()
+
 
 class DiskBackend(Backend):
     """

--- a/circup/wwshell/README.rst
+++ b/circup/wwshell/README.rst
@@ -77,6 +77,7 @@ To get help, just type the command::
                          detection.
       --host TEXT        Hostname or IP address of a device. Overrides automatic
                          path detection.
+      --port INTEGER     HTTP port that the web workflow is listening on.
       --password TEXT    Password to use for authentication when --host is used.
                          You can optionally set an environment variable
                          CIRCUP_WEBWORKFLOW_PASSWORD instead of passing this
@@ -87,10 +88,12 @@ To get help, just type the command::
       --help             Show this message and exit.
 
     Commands:
-      get  Download a copy of a file or directory from the device to the...
-      ls   Lists the contents of a directory.
-      put  Upload a copy of a file or directory from the local computer to...
-      rm   Delete a file on the device.
+      get    Download a copy of a file or directory from the device to the...
+      ls     Lists the contents of a directory.
+      mkdir  Create a directory on the device with specified name.
+      mv     Rename or move a file or directory on the device to the...
+      put    Upload a copy of a file or directory from the local computer to...
+      rm     Delete a file on the device.
 
 
 .. note::

--- a/circup/wwshell/commands.py
+++ b/circup/wwshell/commands.py
@@ -223,9 +223,22 @@ def rm_cli(ctx, file):  # pragma: no cover
 @click.pass_context
 def mkdir_cli(ctx, directory):  # pragma: no cover
     """
-    Create
+    Create a directory on the device with specified name.
     """
     click.echo(f"running: mkdir {directory}")
     ctx.obj["backend"].create_directory(
         ctx.obj["backend"].device_location, ctx.obj["backend"].get_file_path(directory)
     )
+
+
+@main.command("mv")
+@click.argument("file", required=True, nargs=1)
+@click.argument("destination", required=True, nargs=1)
+@click.pass_context
+def mv_cli(ctx, file, destination):  # pragma: no cover
+    """
+    Rename or move a file or directory on the device to the specified destination.
+    """
+
+    click.echo(f"running: mv {file} {destination}")
+    ctx.obj["backend"].move_file(file, destination)


### PR DESCRIPTION
Adds the new wwshell command `mv` that can be used like this:

```
wwshell --host 192.168.1.122 --password passw0rd123 mv code.py somethingelse.py
```

Renames or moves the target file to the destination.