### PR TITLE
update RTD config

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+sphinx
+sphinxcontrib-jquery
+sphinx-rtd-theme

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,23 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
+
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt
 
 requirements_file: requirements.txt


### PR DESCRIPTION
Trying to fix the docs builds and hopefully get `wwshell` listed in the live docs page.

Will resolve: #276 if it is successful, but I don't know of a way to test it without merge and release and then check RTD.

I updated the structure of readthedocs.yml to match the one from a library and added docs/requirements.txt.