### PR TITLE
remove old requirements_file value

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -19,5 +19,3 @@ python:
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt
-
-requirements_file: requirements.txt


### PR DESCRIPTION
The previous attempt to fix the RTD config wasn't fully successfully

Now the error is this:
<img width="990" height="54" alt="image" src="https://github.com/user-attachments/assets/b0bc6966-ec25-4a9d-9a42-1b9dca075157" />

Which I think is because I forgot to remove the old `requirements_file` syntax value from the config file.

Unfortunately RTD instantly re-disables the project after ever failed attempt to fix this issue. So until it is fixed successfully the project has to manually re-enabled in its settings page for each attempt after the changed code is merged.
